### PR TITLE
feat: Add a Unique node type to remove duplicate values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +468,17 @@ dependencies = [
  "fastrand",
  "futures-lite",
  "once_cell",
+]
+
+[[package]]
+name = "bloomfilter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cffe85a8b173164000edb6570ff7cf429acc9460b41d963e797df413f1765b4"
+dependencies = [
+ "bit-vec",
+ "rand 0.8.3",
+ "siphasher",
 ]
 
 [[package]]
@@ -2228,6 +2245,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f100fcfb41e5385e0991f74981732049f9b896821542a219420491046baafdc2"
+dependencies = [
+ "num-traits",
+ "rand 0.8.3",
+ "serde",
+]
+
+[[package]]
 name = "os_info"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3279,11 +3307,12 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "bimap",
  "bincode",
+ "bloomfilter",
  "chrono",
  "colored",
  "env_logger",
@@ -3307,9 +3336,10 @@ dependencies = [
 
 [[package]]
 name = "synth-gen"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "fake",
+ "ordered-float",
  "rand 0.8.3",
  "serde",
  "serde_json",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "synth-core"
-version = "0.5.0"
+version = "0.5.1"
 authors = [
   "Damien Broka <damien@getsynth.com>",
   "Christos Hadjiaslanis <christos@getsynth.com>",
@@ -37,3 +37,4 @@ synth-gen = { path = "../gen", features = [ "shared" ] }
 uuid = { version = "0.8.2", features = ["v4"] }
 bimap = { version = "0.6.0", features = [ "std" ] }
 humantime-serde = "1.0.1"
+bloomfilter = "1.0.5"

--- a/core/src/graph/mod.rs
+++ b/core/src/graph/mod.rs
@@ -78,6 +78,9 @@ pub use array::ArrayNode;
 pub mod object;
 pub use object::{KeyValueOrNothing, ObjectNode};
 
+pub mod unique;
+pub use unique::UniqueNode;
+
 pub mod one_of;
 pub(crate) mod series;
 
@@ -174,15 +177,15 @@ where
 }
 
 derive_from! {
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
     pub enum Value {
-    Null(()),
-    Bool(bool),
-    Number(Number),
-    String(String),
-    DateTime(ChronoValue),
-    Object(BTreeMap<String, Value>),
-    Array(Vec<Value>),
+        Null(()),
+        Bool(bool),
+        Number(Number),
+        String(String),
+        DateTime(ChronoValue),
+        Object(BTreeMap<String, Value>),
+        Array(Vec<Value>),
     }
 }
 
@@ -245,6 +248,7 @@ derive_generator!(
         View(Unwrapped<View<Graph>>),
         Scoped(Scoped<Graph>),
         Series(SeriesNode),
+        Unique(UniqueNode)
     }
 );
 

--- a/core/src/graph/string/faker.rs
+++ b/core/src/graph/string/faker.rs
@@ -173,12 +173,13 @@ pub struct RandFaker {
 }
 
 impl RandFaker {
-    pub(crate) fn new(generator: String, args: FakerArgs) -> Result<Self, anyhow::Error> {
-        match FAKE_MAP.get(generator.as_str()) {
+    pub(crate) fn new<S: AsRef<str>>(generator: S, args: FakerArgs) -> Result<Self, anyhow::Error> {
+        match FAKE_MAP.get(generator.as_ref()) {
             None => Err(anyhow!(
                 "Generator '{}' does not exist {}",
-                generator,
-                suggest_closest(FAKE_MAP.keys(), &generator).unwrap_or_else(|| "".to_string())
+                generator.as_ref(),
+                suggest_closest(FAKE_MAP.keys(), &generator.as_ref())
+                    .unwrap_or_else(|| "".to_string())
             )),
             Some(generator) => Ok(Self {
                 generator: *generator,

--- a/core/src/graph/unique.rs
+++ b/core/src/graph/unique.rs
@@ -1,0 +1,100 @@
+use crate::graph::prelude::{
+    Error, Generator, GeneratorState, Rng, Token, TryFilterMap, TryGeneratorExt, Value,
+};
+use crate::Graph;
+
+use std::collections::HashMap;
+use std::hash::{BuildHasher, Hash, Hasher};
+
+const MAX_RETRIES: usize = 64;
+
+type ValueFilter =
+    TryFilterMap<Box<Graph>, Box<dyn FnMut(Value) -> Result<Option<Value>, Error>>, Value>;
+
+derive_generator! {
+    yield Token,
+    return Result<Value, Error>,
+    pub enum UniqueNode {
+        Hash(ValueFilter),
+    }
+}
+
+impl UniqueNode {
+    pub fn hash(inner: Graph) -> Self {
+        let mut seen: HashMap<u64, usize> = HashMap::new();
+        let filter = move |value: Value| {
+            let mut hasher = seen.hasher().build_hasher();
+            value.hash(&mut hasher);
+            let hash = hasher.finish();
+
+            let count = seen
+                .entry(hash)
+                .and_modify(|i| {
+                    *i += 1;
+                })
+                .or_insert(0);
+
+            match *count {
+                0 => Ok(Some(value)),
+                x if x < MAX_RETRIES => Ok(None),
+                _ => Err(failed_crate!(
+                    target: Release,
+                    "Could not generate enough unique values from this generator:\
+                         try reducing the number of values generated"
+                )),
+            }
+        };
+        Self::Hash(Box::new(inner).try_filter_map(Box::new(filter)))
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::graph::{
+        prelude::{Generator, GeneratorExt},
+        Graph, NumberNode, RandFaker, RandomString, RandomU64, RangeStep, StringNode,
+    };
+    use std::collections::HashSet;
+
+    const NUM_GENERATED: usize = 1024;
+
+    #[test]
+    fn unique_node() {
+        let usernames = Graph::String(StringNode::from(RandomString::from(
+            RandFaker::new("username", Default::default()).unwrap(),
+        )));
+        let mut rng = rand::thread_rng();
+        let output = UniqueNode::hash(usernames)
+            .repeat(NUM_GENERATED)
+            .complete(&mut rng)
+            .into_iter()
+            .collect::<Result<HashSet<_>, _>>()
+            .unwrap();
+        assert_eq!(output.len(), NUM_GENERATED);
+
+        let numbers = Graph::Number(NumberNode::from(
+            RandomU64::range(RangeStep {
+                low: 0,
+                high: NUM_GENERATED as u64,
+                step: 1,
+            })
+            .unwrap(),
+        ));
+        let output = UniqueNode::hash(numbers)
+            .repeat(NUM_GENERATED)
+            .complete(&mut rng)
+            .into_iter()
+            .collect::<Result<HashSet<_>, _>>()
+            .unwrap();
+        assert_eq!(output.len(), NUM_GENERATED);
+
+        let constant = Graph::Number(NumberNode::from(RandomU64::constant(44)));
+        let output = UniqueNode::hash(constant)
+            .repeat(10)
+            .complete(&mut rng)
+            .into_iter()
+            .collect::<Result<HashSet<_>, _>>();
+        assert!(output.is_err());
+    }
+}

--- a/core/src/schema/content/mod.rs
+++ b/core/src/schema/content/mod.rs
@@ -43,11 +43,13 @@ pub use categorical::{Categorical, CategoricalType};
 pub use number::Id;
 pub mod prelude;
 pub(crate) mod series;
+pub(crate) mod unique;
 
 use prelude::*;
 
 use super::FieldRef;
 use crate::schema::content::series::SeriesContent;
+use crate::schema::unique::UniqueContent;
 
 pub trait Find<C> {
     fn find<I, R>(&self, reference: I) -> Result<&C>
@@ -98,6 +100,7 @@ pub enum Content {
     SameAs(SameAsContent),
     OneOf(OneOfContent),
     Series(SeriesContent),
+    Unique(UniqueContent),
 }
 
 impl Content {
@@ -107,6 +110,7 @@ impl Content {
 
     pub fn accepts(&self, value: &Value) -> Result<()> {
         match self {
+            Self::Unique(unique_content) => unique_content.content.accepts(value),
             Self::SameAs(_) => Ok(()),
             Self::OneOf(one_of_content) => {
                 let res: Vec<_> = one_of_content
@@ -190,6 +194,7 @@ impl Content {
             Content::SameAs(_) => "same_as",
             Content::OneOf(_) => "one_of",
             Content::Series(_) => "series",
+            Content::Unique(_) => "unique",
         }
     }
 }
@@ -312,6 +317,7 @@ impl Compile for Content {
             Self::SameAs(same_as_content) => same_as_content.compile(compiler),
             Self::OneOf(one_of_content) => one_of_content.compile(compiler),
             Self::Series(series_content) => series_content.compile(compiler),
+            Self::Unique(unique_content) => unique_content.compile(compiler),
             Self::Null => Ok(Graph::null()),
         }
     }

--- a/core/src/schema/content/string.rs
+++ b/core/src/schema/content/string.rs
@@ -186,7 +186,7 @@ pub struct JsonContent {
     content: Box<Content>,
 }
 
-#[derive(Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Clone, Hash)]
 pub enum ChronoValue {
     NaiveDate(NaiveDate),
     NaiveTime(NaiveTime),

--- a/core/src/schema/content/unique.rs
+++ b/core/src/schema/content/unique.rs
@@ -1,0 +1,34 @@
+use crate::compile::Compile;
+use crate::graph::UniqueNode;
+use crate::{Compiler, Content, Graph};
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub enum UniqueAlgorithm {
+    Hash,
+}
+
+impl Default for UniqueAlgorithm {
+    fn default() -> Self {
+        Self::Hash
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct UniqueContent {
+    #[serde(default)]
+    pub algorithm: UniqueAlgorithm,
+    pub content: Box<Content>,
+}
+
+impl Compile for UniqueContent {
+    fn compile<'a, C: Compiler<'a>>(&'a self, compiler: C) -> Result<Graph> {
+        let graph = self.content.compile(compiler)?;
+        let node = match self.algorithm {
+            UniqueAlgorithm::Hash => UniqueNode::hash(graph),
+        };
+        Ok(Graph::Unique(node))
+    }
+}

--- a/gen/Cargo.toml
+++ b/gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "synth-gen"
-version = "0.4.0"
+version = "0.4.1"
 authors = [
   "Damien Broka <damien@getsynth.com>",
   "Christos Hadjiaslanis <christos@getsynth.com>"
@@ -21,5 +21,5 @@ shared = [ ]
 [dependencies]
 serde = { version = "1.0", features = [ "derive" ] }
 rand = "0.8.3"
-
+ordered-float = { version = "2.0", features = ["serde", "rand"] }
 fake = { git = "https://github.com/cksac/fake-rs", features = ["http"], rev = "ab095c1f8cf230cfa94305339b4e08bd02a275d4", optional = true }

--- a/gen/src/de.rs
+++ b/gen/src/de.rs
@@ -48,8 +48,8 @@ macro_rules! deserialize_number_helper {
     (u32) => (deserialize_number_impl!(u32 => deserialize_u32 visit_u32););
     (u64) => (deserialize_number_impl!(u64 => deserialize_u64 visit_u64););
     (u128) => (deserialize_number_impl!(u128 => deserialize_u128 visit_u128););
-    (f32) => (deserialize_number_impl!(f32 => deserialize_f32 visit_f32););
-    (f64) => (deserialize_number_impl!(f64 => deserialize_f64 visit_f64););
+    (OrderedFloat32) => (deserialize_number_impl!(OrderedFloat32 => deserialize_f32 visit_f32););
+    (OrderedFloat64) => (deserialize_number_impl!(OrderedFloat64 => deserialize_f64 visit_f64););
 }
 
 macro_rules! deserialize_number_impl {
@@ -252,7 +252,20 @@ where
     Vec<u8> => deserialize_byte_buf visit_byte_buf,
     );
 
-    deserialize_number!(i8, i16, i32, i64, i128, u8, u16, u32, u64, u128, f32, f64,);
+    deserialize_number!(
+        i8,
+        i16,
+        i32,
+        i64,
+        i128,
+        u8,
+        u16,
+        u32,
+        u64,
+        u128,
+        OrderedFloat32,
+        OrderedFloat64,
+    );
 
     deserialize_redirect!(
     deserialize_str -> deserialize_string,

--- a/gen/src/error.rs
+++ b/gen/src/error.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use crate::value::{IntoToken, Special, Token};
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Error {
     Type { expected: String, got: String },
     Deserialize { msg: String },


### PR DESCRIPTION
This adds a naive `UniqueNode` type to the generator graph that removes duplicates from values generated by an inner node. This allows to, for example, generate only distinct instances of usernames, addresses, and even works for compound structures like arrays or objects.

This also adds a `UniqueContent` node to the schema in order to make the feature accessible from the JSON schema. An example usage is:
```json
{
    "type": "unique",
    "content": {
        "type": "string",
        "date_time": {
            "format": "%Y-%m-%dT%H:%M:%S%z",
            "begin": "2000-01-01T00:00:00+0000",
            "end": "2020-01-01T00:00:00+0000"
        }
    }
}
```

Closes #10.