### PR TITLE
docs: fix typo in string.md

### DIFF
--- a/docs/docs/content/string.md
+++ b/docs/docs/content/string.md
@@ -842,4 +842,5 @@ The value of the `"categorical"` key must be an object whose:
 - keys are the allowed values of the categorical (e.g. `"pawn"`, `"rook"`, etc.),
 - values are non-negative integers defining the relative weight of the corresponding variant (e.g. `8`, `2`, etc.).
 
-[faker]: https://faker.readthedocs.io/en/master/
+[faker]: https://github.com/cksac/fake-rs
+

--- a/docs/docs/content/string.md
+++ b/docs/docs/content/string.md
@@ -32,7 +32,7 @@ This generator has no parameters.
 
 ## faker
 
-Synth has na internal fake data generator which will generate fake data for semantic types such as Names, Addresses etc.
+Synth has an internal fake data generator that will generate fake data for semantic types such as Names, Addresses, etc.
 
 #### Example
 


### PR DESCRIPTION
Hi,

I was going through the docs and found a small typo in the [string generator page](https://getsynth.github.io/synth/content/string#faker). This PR simply fixes the typo and improves the related sentence (as well as a missing newline character in the last line 😅).