### PR TITLE
feat: Add a formatter generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,6 +957,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dynfmt"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c298552016db86f0d49e5de09818dd86c536f66095013cc415f4f85744033f"
+dependencies = [
+ "erased-serde",
+ "lazy_static",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,6 +1014,15 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "erased-serde"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3de9ad4541d99dc22b59134e7ff8dc3d6c988c89ecd7324bf10a8362b07a2afa"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3315,6 +3338,7 @@ dependencies = [
  "bloomfilter",
  "chrono",
  "colored",
+ "dynfmt",
  "env_logger",
  "fake",
  "humantime-serde",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -38,3 +38,4 @@ uuid = { version = "0.8.2", features = ["v4"] }
 bimap = { version = "0.6.0", features = [ "std" ] }
 humantime-serde = "1.0.1"
 bloomfilter = "1.0.5"
+dynfmt = { version = "0.1.5", features = [ "curly" ] }

--- a/core/src/graph/mod.rs
+++ b/core/src/graph/mod.rs
@@ -64,7 +64,9 @@ pub mod null;
 pub use null::NullNode;
 
 pub mod string;
-pub use string::{RandFaker, RandomDateTime, RandomString, StringNode, Truncated, UuidGen};
+pub use string::{
+    Format, FormatArgs, RandFaker, RandomDateTime, RandomString, StringNode, Truncated, UuidGen,
+};
 
 pub mod number;
 pub use number::{Incrementing, NumberNode, RandomF64, RandomI64, RandomU64, UniformRangeStep};
@@ -332,6 +334,7 @@ pub mod tests {
     use rand::thread_rng;
 
     use super::*;
+    use crate::schema::ChronoValueFormatter;
 
     use crate::schema::tests::USER_NAMESPACE;
 
@@ -339,137 +342,153 @@ pub mod tests {
     fn schema_to_generator() {
         let schema: Namespace = from_json!({
             "users": {
-        "type": "array",
-        "length": {
-            "type": "number",
-            "subtype": "u64",
-            "constant": 10
-        },
-        "content": {
-            "type": "object",
-            "id" : {
-            "type" : "number",
-            "subtype" : "u64",
-            "id" : {
-            "start_at" : 100
-            }
-            },
-            "is_active": {
-            "type": "bool",
-            "frequency": 0.2
-            },
-            "username": {
-                "type": "string",
-                "truncated": {
-                    "content": {
+                "type": "array",
+                "length": {
+                    "type": "number",
+                    "subtype": "u64",
+                    "constant": 10
+                },
+                "content": {
+                    "type": "object",
+                    "id" : {
+                        "type" : "number",
+                        "subtype" : "u64",
+                        "id" : {
+                            "start_at" : 100
+                        }
+                    },
+                    "is_active": {
+                        "type": "bool",
+                        "frequency": 0.2
+                    },
+                    "username": {
                         "type": "string",
-                        "pattern": "[a-zA-Z0-9]{0, 255}"
+                        "truncated": {
+                            "content": {
+                                "type": "string",
+                                "pattern": "[a-zA-Z0-9]{0, 255}"
+                            },
+                            "length": 5
+                        }
                     },
-                    "length": 5
-                }
-            },
-            "bank_country": {
-            "type": "string",
-            "pattern": "(GB|ES)"
+                    "bank_country": {
+                        "type": "string",
+                        "pattern": "(GB|ES)"
                     },
-            "num_logins": {
-            "type": "number",
-            "subtype": "u64",
-            "range": {
-                "high": 100,
-                "low": 0,
-                "step": 1
-            }
-            },
-            "currency": {
-            "type": "string",
-            "pattern": "(USD|GBP)"
+                    "num_logins": {
+                        "type": "number",
+                        "subtype": "u64",
+                        "range": {
+                            "high": 100,
+                            "low": 0,
+                            "step": 1
+                        }
                     },
-            "credit_card": {
-            "type": "string",
-                "faker": {
-                    "generator": "credit_card"
-                }
-            },
-            "created_at_date": {
-            "type": "string",
-            "date_time": {
-                "format": "%Y-%m-%d"
-            }
-            },
-            "created_at_time": {
-            "type": "string",
-            "date_time": {
-                "format": "%H:%M:%S"
-            }
-            },
-            "last_login_at": {
-            "type": "string",
-            "date_time": {
-                "format": "%Y-%m-%dT%H:%M:%S%z",
-                "begin": "2020-01-01T00:00:00+0000"
-            }
-            },
-            "maybe_an_email": {
-            "optional": true,
-            "type": "string",
-            "faker": {
-                "generator": "safe_email"
-            }
-            },
-            "num_logins_again": {
-            "type": "same_as",
-            "ref": "users.content.num_logins"
-            }
+                    "currency": {
+                        "type": "string",
+                        "pattern": "(USD|GBP)"
+                    },
+                    "credit_card": {
+                        "type": "string",
+                        "faker": {
+                            "generator": "credit_card"
+                        }
+                    },
+                    "formatted_username": {
+                        "type": "string",
+                        "format": {
+                            "format": "my username is {name} and I trade in {currency}",
+                            "arguments": {
+                                "name": {
+                                    "type": "same_as",
+                                    "ref": "users.content.username"
+                                },
+                                "currency": {
+                                    "type": "same_as",
+                                    "ref": "users.content.currency"
+                                }
+                            }
+                        }
+                    },
+                    "created_at_date": {
+                        "type": "string",
+                        "date_time": {
+                            "format": "%Y-%m-%d"
+                        }
+                    },
+                    "created_at_time": {
+                        "type": "string",
+                        "date_time": {
+                            "format": "%H:%M:%S"
+                        }
+                    },
+                    "last_login_at": {
+                        "type": "string",
+                        "date_time": {
+                            "format": "%Y-%m-%dT%H:%M:%S%z",
+                            "begin": "2020-01-01T00:00:00+0000"
+                        }
+                    },
+                    "maybe_an_email": {
+                        "optional": true,
+                        "type": "string",
+                        "faker": {
+                            "generator": "safe_email"
+                        }
+                    },
+                    "num_logins_again": {
+                        "type": "same_as",
+                        "ref": "users.content.num_logins"
+                    }
                 }
             },
             "transactions": {
-        "type": "array",
-        "length": {
-            "type": "number",
-            "subtype": "u64",
-            "constant": 100
-        },
-        "content": {
-            "type": "object",
-            "username": {
-            "type": "same_as",
-            "ref": "users.content.username"
-            },
-            "currency": {
-            "type": "same_as",
-            "ref": "users.content.currency"
-            },
-            "timestamp": {
-            "type": "string",
-            "date_time": {
-                "format": "%Y-%m-%dT%H:%M:%S%z",
-                "begin": "2020-01-01T00:00:00+0000"
-            }
-            },
-            "amount": {
-            "type": "number",
-            "subtype": "f64",
-            "range": {
-                "high": 10000,
-                "low": 0,
-                "step": 0.1
-            }
-            },
-            "serialized_nonce": {
-            "type" : "string",
-            "serialized" : {
-                "serializer" : "json",
-                 "content" : {
-                 "type" : "object",
-                 "nonce" : {
-                     "type" : "string",
-                     "pattern" : "[A-Z a-z 0-9]+",
+                "type": "array",
+                "length": {
+                    "type": "number",
+                    "subtype": "u64",
+                    "constant": 100
+                },
+                "content": {
+                    "type": "object",
+                    "username": {
+                        "type": "same_as",
+                        "ref": "users.content.username"
+                    },
+                    "currency": {
+                        "type": "same_as",
+                        "ref": "users.content.currency"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "date_time": {
+                            "format": "%Y-%m-%dT%H:%M:%S%z",
+                            "begin": "2020-01-01T00:00:00+0000"
+                        }
+                    },
+                    "amount": {
+                        "type": "number",
+                        "subtype": "f64",
+                        "range": {
+                            "high": 10000,
+                            "low": 0,
+                            "step": 0.1
+                        }
+                    },
+                    "serialized_nonce": {
+                        "type" : "string",
+                        "serialized" : {
+                            "serializer" : "json",
+                            "content" : {
+                                "type" : "object",
+                                "nonce" : {
+                                    "type" : "string",
+                                    "pattern" : "[A-Z a-z 0-9]+",
+                                }
+                            }
+                        }
+                    },
                 }
-                }
-             }
-            },
-        }
             }
         });
 
@@ -508,6 +527,7 @@ pub mod tests {
             currency: String,
             credit_card: String,
             maybe_an_email: Option<String>,
+            formatted_username: String,
             is_active: bool,
             created_at_date: String,
             created_at_time: String,
@@ -531,29 +551,17 @@ pub mod tests {
                 assert!(user.username.len() <= 5);
                 all_users.insert(user.username.clone());
                 currencies.insert(user.username, user.currency);
-                /*
-                       if let Some(email) = user.maybe_an_email {
-                           if !user.is_active {
-                               assert!(
-                                   email.contains("inactive"),
-                                   "email did not contain inactive: {}",
-                                   email
-                               )
-                           }
-                       }
+                ChronoValueFormatter::new("%Y-%m-%d")
+                    .parse(&user.created_at_date)
+                    .unwrap();
 
-                       ChronoContentFormatter::new("%Y-%m-%d")
-                           .parse(&user.created_at_date)
-                           .unwrap();
+                ChronoValueFormatter::new("%H:%M:%S")
+                    .parse(&user.created_at_time)
+                    .unwrap();
 
-                       ChronoContentFormatter::new("%H:%M:%S")
-                           .parse(&user.created_at_time)
-                           .unwrap();
-
-                       ChronoContentFormatter::new("%Y-%m-%dT%H:%M:%S%z")
-                           .parse(&user.last_login_at)
-                           .unwrap();
-                */
+                ChronoValueFormatter::new("%Y-%m-%dT%H:%M:%S%z")
+                    .parse(&user.last_login_at)
+                    .unwrap();
             }
             assert_eq!(all_users.len(), 10);
 

--- a/core/src/graph/string/format.rs
+++ b/core/src/graph/string/format.rs
@@ -1,0 +1,138 @@
+use crate::graph::prelude::*;
+use anyhow::Result;
+
+use dynfmt::{self, Format as DynFormat};
+
+type Formatted = TryOnce<Unwrap<Yield<Result<String, Error>>>>;
+
+type FormatFn = Box<dyn Fn(FormatArgs<String>) -> Formatted>;
+
+derive_generator! {
+    yield String,
+    return Result<String, Error>,
+    pub struct Format(AndThenTry<FormatArgs<Graph>, FormatFn, Formatted>);
+}
+
+impl Format {
+    pub fn new(fmt: String, args: FormatArgs<Graph>) -> Self {
+        let format = move |args: FormatArgs<String>| {
+            let formatted = dynfmt::SimpleCurlyFormat
+                .format(fmt.as_str(), args)
+                .map(|res| res.into_owned())
+                .map_err(|err| failed_crate!(target: Release, "formatting error: {:?}", err));
+            Yield::wrap(formatted).unwrap().try_once()
+        };
+        Self(args.and_then_try(Box::new(format)))
+    }
+}
+
+pub struct FormatArgs<G> {
+    pub unnamed: Vec<G>,
+    pub named: HashMap<String, G>,
+}
+
+impl<G> Default for FormatArgs<G> {
+    fn default() -> Self {
+        Self {
+            unnamed: Vec::new(),
+            named: HashMap::new(),
+        }
+    }
+}
+
+impl<G> Generator for FormatArgs<G>
+where
+    G: Generator<Return = Result<Value, Error>>,
+{
+    type Yield = String;
+
+    type Return = Result<FormatArgs<String>, Error>;
+
+    fn next<R: Rng>(&mut self, rng: &mut R) -> GeneratorState<Self::Yield, Self::Return> {
+        GeneratorState::Complete(
+            try {
+                FormatArgs {
+                    unnamed: self
+                        .unnamed
+                        .iter_mut()
+                        .map(|unnamed| unnamed.complete(rng).and_then(|value| value.try_into()))
+                        .collect::<Result<_, Error>>()?,
+                    named: self
+                        .named
+                        .iter_mut()
+                        .map(|(key, named)| {
+                            Ok((
+                                key.clone(),
+                                named.complete(rng).and_then(|value| value.try_into())?,
+                            ))
+                        })
+                        .collect::<Result<_, Error>>()?,
+                }
+            },
+        )
+    }
+}
+
+impl dynfmt::FormatArgs for FormatArgs<String> {
+    fn get_index(&self, index: usize) -> std::result::Result<Option<dynfmt::Argument<'_>>, ()> {
+        Ok(self.unnamed.get(index).map(|arg| arg as dynfmt::Argument))
+    }
+
+    fn get_key(&self, key: &str) -> std::result::Result<Option<dynfmt::Argument<'_>>, ()> {
+        Ok(self.named.get(key).map(|arg| arg as dynfmt::Argument))
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::graph::{Graph, RandFaker, RandomString, StringNode};
+
+    fn faker_graph(name: &str) -> Graph {
+        Graph::String(StringNode::from(RandomString::from(
+            RandFaker::new(name, Default::default()).unwrap(),
+        )))
+    }
+
+    #[test]
+    fn format_with_named_args() {
+        let mut rng = rand::thread_rng();
+
+        let args = FormatArgs {
+            named: vec![
+                ("name".to_string(), faker_graph("username")),
+                ("email".to_string(), faker_graph("safe_email")),
+            ]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        };
+        let formatted = Format::new(
+            "my email is {email} and my username is {name}".to_string(),
+            args,
+        );
+        formatted
+            .repeat(1024)
+            .complete(&mut rng)
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+    }
+
+    #[test]
+    fn format_with_unnamed_args() {
+        let mut rng = rand::thread_rng();
+
+        let args = FormatArgs {
+            unnamed: vec![faker_graph("username"), faker_graph("safe_email")],
+            ..Default::default()
+        };
+        let formatted = Format::new("my email is {} and my username is {}".to_string(), args);
+        formatted
+            .repeat(1024)
+            .complete(&mut rng)
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+    }
+}

--- a/core/src/graph/string/mod.rs
+++ b/core/src/graph/string/mod.rs
@@ -6,12 +6,14 @@ pub mod date_time;
 pub use date_time::RandomDateTime;
 
 pub mod faker;
+pub mod format;
 pub mod serialized;
 pub mod truncated;
 pub mod uuid;
 
 pub use self::uuid::UuidGen;
-pub use faker::{RandFaker, FakerArgs, Locale};
+pub use faker::{FakerArgs, Locale, RandFaker};
+pub use format::{Format, FormatArgs};
 pub use serialized::Serialized;
 pub use truncated::Truncated;
 
@@ -23,7 +25,8 @@ derive_generator! {
         Faker(TryOnce<RandFaker>),
         Serialized(TryOnce<Serialized>)
         Categorical(OnceInfallible<Random<String, Categorical<String>>>)
-        Uuid(OnceInfallible<UuidGen>)
+        Uuid(OnceInfallible<UuidGen>),
+        Format(Format),
         Truncated(Truncated)
     }
 }
@@ -64,13 +67,18 @@ impl From<Truncated> for RandomString {
     }
 }
 
+impl From<Format> for RandomString {
+    fn from(format: Format) -> Self {
+        RandomString::Format(format)
+    }
+}
+
 derive_generator! {
     yield Token,
     return Result<Value, Error>,
-    pub enum
-    StringNode {
-    String(Valuize<Tokenizer<RandomString>, String>),
-    DateTime(Valuize<Tokenizer<RandomDateTime>, ChronoValue>)
+    pub enum StringNode {
+        String(Valuize<Tokenizer<RandomString>, String>),
+        DateTime(Valuize<Tokenizer<RandomDateTime>, ChronoValue>)
     }
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,7 +3,8 @@
     async_closure,
     map_first_last,
     box_patterns,
-    error_iter
+    error_iter,
+    try_blocks
 )]
 #![allow(type_alias_bounds)]
 #![deny(warnings)]

--- a/core/src/schema/content/prelude.rs
+++ b/core/src/schema/content/prelude.rs
@@ -9,6 +9,7 @@ pub(super) use serde_json::{Map, Number, Value};
 pub(super) type JsonObject = Map<String, Value>;
 
 // std
+pub(super) use std::collections::HashMap;
 pub(super) use std::convert::TryFrom;
 pub(super) use std::fmt::{Display, Formatter};
 pub(super) use std::hash::Hash;

--- a/core/src/schema/content/string.rs
+++ b/core/src/schema/content/string.rs
@@ -12,6 +12,7 @@ pub enum StringContent {
     Serialized(SerializedContent),
     Uuid(Uuid),
     Truncated(TruncatedContent),
+    Format(FormatContent),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -27,6 +28,7 @@ impl StringContent {
             Self::Serialized(_) => "serialized",
             Self::Uuid(_) => "uuid",
             Self::Truncated(_) => "truncated",
+            Self::Format(_) => "format",
         }
     }
 }
@@ -131,12 +133,12 @@ impl<'de> Deserialize<'de> for FakerContentArgument {
     {
         let value = Value::deserialize(deserializer)?;
         match &value {
-	    Value::Number(_) |
-	    Value::String(_) |
-	    Value::Bool(_) => Ok(Self(value)),
-	    _ => {
-		Err(D::Error::custom("invalid argument for a faker generator: can only be of a primitive type (i.e. one of string, number or boolean)"))
-	    }
+            Value::Number(_) |
+            Value::String(_) |
+            Value::Bool(_) => Ok(Self(value)),
+            _ => {
+                Err(D::Error::custom("invalid argument for a faker generator: can only be of a primitive type (i.e. one of string, number or boolean)"))
+            }
         }
     }
 }
@@ -179,6 +181,21 @@ pub enum SerializedContent {
 pub struct TruncatedContent {
     content: Box<Content>,
     length: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub struct FormatContent {
+    format: String,
+    arguments: HashMap<String, Content>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "lowercase")]
+#[serde(untagged)]
+pub enum ContentOrRef {
+    Content(Content),
+    FieldRef(FieldRef),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -459,14 +476,14 @@ pub mod datetime_content {
                 .and_then(|begin| begin.common_variant(end.as_ref()?));
 
             match common_variant {
-		Some(variant) if variant != type_ => Err(failed!(target: Release, "content types of 'begin' and 'end' mismatch: begin is a {:?}, end is a {:?}; this is not allowed here. Try specifying the 'type' field.", begin, end)),
-		_ => Ok(DateTimeContent {
+                Some(variant) if variant != type_ => Err(failed!(target: Release, "content types of 'begin' and 'end' mismatch: begin is a {:?}, end is a {:?}; this is not allowed here. Try specifying the 'type' field.", begin, end)),
+                _ => Ok(DateTimeContent {
                     format: self.format,
                     type_,
                     begin,
                     end,
                 })
-	    }
+            }
         }
 
         pub(super) fn from_datetime_content(c: &DateTimeContent) -> Result<Self> {
@@ -486,6 +503,7 @@ pub mod datetime_content {
 }
 
 use crate::graph::string::Serialized;
+use crate::schema::FieldRef;
 pub use datetime_content::ChronoValueFormatter;
 
 impl Serialize for DateTimeContent {
@@ -510,8 +528,18 @@ impl<'de> Deserialize<'de> for DateTimeContent {
 }
 
 impl Compile for StringContent {
-    fn compile<'a, C: Compiler<'a>>(&'a self, compiler: C) -> Result<Graph> {
+    fn compile<'a, C: Compiler<'a>>(&'a self, mut compiler: C) -> Result<Graph> {
         let string_node = match self {
+            StringContent::Format(FormatContent { format, arguments }) => {
+                let args = FormatArgs {
+                    named: arguments
+                        .iter()
+                        .map(|(name, value)| Ok((name.to_string(), compiler.build(name, value)?)))
+                        .collect::<Result<_>>()?,
+                    ..Default::default()
+                };
+                RandomString::from(Format::new(format.to_string(), args)).into()
+            }
             StringContent::Pattern(pattern) => RandomString::from(pattern.to_regex()).into(),
             StringContent::Faker(FakerContent {
                 generator,

--- a/core/src/schema/inference/mod.rs
+++ b/core/src/schema/inference/mod.rs
@@ -113,6 +113,7 @@ impl MergeStrategy<StringContent, String> for OptionalMergeStrategy {
             StringContent::Serialized(_) => Ok(()), // we can probably do better here
             StringContent::Uuid(_) => Ok(()),
             StringContent::Truncated(_) => Ok(()),
+            StringContent::Format(_) => Ok(())
         }
     }
 }

--- a/docs/docs/content/string.md
+++ b/docs/docs/content/string.md
@@ -30,6 +30,36 @@ This generator has no parameters.
 }
 ```
 
+## format
+
+`format` allows to format one or more string values by parsing a parametric
+format string and processing the specified replacements.
+
+#### Example
+
+```json synth
+{
+  "type": "string",
+  "format": {
+    "format": "my name is {name} and my email is {email}",
+    "arguments": {
+      "name": {
+        "type": "string",
+        "faker": {
+          "generator": "username"
+        }
+      },
+      "email": {
+        "type": "string",
+        "faker": {
+          "generator": "safe_email"
+        }
+      }
+    }
+  }
+}
+```
+
 ## faker
 
 Synth has na internal fake data generator which will generate fake data for semantic types such as Names, Addresses etc.


### PR DESCRIPTION
This adds a `RandomString::Format` variant to the generator graph that wraps around [`dynfmt::SimpleCurlyFormat`](https://docs.rs/dynfmt/0.1.5/dynfmt/curly/struct.SimpleCurlyFormat.html). This provides a simplified version of the Rust-style [`format!`](https://doc.rust-lang.org/std/macro.format.html) macro features from within Synth.

Also includes:
* A couple code formatting tweaks
* The addition of a `FormatContent` to the schema, for the feature to be accessible from the JSON schema
* Documentation for the `format` string variant in the JSON schema
* Elementary smoke tests that check the generator works in simple cases


### Example usage
```json
{
  "type": "string",
  "format": {
    "format": "my name is {name} and my email is {email}",
    "arguments": {
      "name": {
        "type": "string",
        "faker": {
          "generator": "username"
        }
      },
      "email": {
        "type": "string",
        "faker": {
          "generator": "safe_email"
        }
      }
    }
  }
}
```