### PR TITLE
feat: Allow the use of some literals wherever Content is accepted

### DIFF
--- a/core/src/schema/content/mod.rs
+++ b/core/src/schema/content/mod.rs
@@ -154,7 +154,7 @@ macro_rules! content {
                     content: __Content
                 }
 
-                 struct Visitor;
+                struct Visitor;
 
                 impl<'de> serde::de::Visitor<'de> for Visitor {
                     type Value = Content;
@@ -167,7 +167,6 @@ macro_rules! content {
                     where
                     A: serde::de::MapAccess<'de>
                     {
-                        use serde::de::MapAccess;
                         use serde::de::IntoDeserializer;
                         let mut out = HashMap::<String, serde_json::Value>::new();
                         while let Some(key) = map.next_key()? {
@@ -210,8 +209,7 @@ macro_rules! content {
                     {
                         if v.starts_with("@") {
                             let ref_ = FieldRef::deserialize(v[1..].into_deserializer())?;
-                            let content = Content::SameAs(SameAsContent { ref_ });
-                            Ok(content)
+                            Ok(Content::SameAs(SameAsContent { ref_ }))
                         } else {
                             Err(E::custom("string literals are synonymous to `same_as` and must start with `@` followed by the address of the referent"))
                         }

--- a/core/src/schema/content/mod.rs
+++ b/core/src/schema/content/mod.rs
@@ -207,8 +207,8 @@ macro_rules! content {
                     where
                     E: serde::de::Error
                     {
-                        if v.starts_with("@") {
-                            let ref_ = FieldRef::deserialize(v[1..].into_deserializer())?;
+                        if let Some(s) = v.strip_prefix("@") {
+                            let ref_ = FieldRef::deserialize(s.into_deserializer())?;
                             Ok(Content::SameAs(SameAsContent { ref_ }))
                         } else {
                             Err(E::custom("string literals are synonymous to `same_as` and must start with `@` followed by the address of the referent"))

--- a/core/src/schema/content/mod.rs
+++ b/core/src/schema/content/mod.rs
@@ -13,7 +13,7 @@
 //! - Things that belong to those submodules that also need to be exposed
 //!   to other parts of `synth` should be re-exported here.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::IntoDeserializer};
 use serde_json::Value;
 
 mod r#bool;
@@ -32,7 +32,7 @@ mod array;
 pub use array::ArrayContent;
 
 mod object;
-pub use object::{FieldContent, ObjectContent};
+pub use object::ObjectContent;
 
 mod one_of;
 pub use one_of::{OneOfContent, VariantContent};
@@ -42,14 +42,16 @@ pub use categorical::{Categorical, CategoricalType};
 
 pub use number::Id;
 pub mod prelude;
+
 pub(crate) mod series;
-pub(crate) mod unique;
+
+pub mod unique;
+pub use unique::{UniqueAlgorithm, UniqueContent};
 
 use prelude::*;
 
 use super::FieldRef;
 use crate::schema::content::series::SeriesContent;
-use crate::schema::unique::UniqueContent;
 
 pub trait Find<C> {
     fn find<I, R>(&self, reference: I) -> Result<&C>
@@ -87,25 +89,198 @@ pub struct SameAsContent {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[serde(rename_all = "snake_case")]
-#[serde(tag = "type")]
-#[serde(deny_unknown_fields)]
-pub enum Content {
-    Null,
-    Bool(BoolContent),
-    Number(NumberContent),
-    String(StringContent),
-    Array(ArrayContent),
-    Object(ObjectContent),
-    SameAs(SameAsContent),
-    OneOf(OneOfContent),
-    Series(SeriesContent),
-    Unique(UniqueContent),
+pub struct NullContent;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ContentLabels {
+    #[serde(default)]
+    optional: bool,
+    #[serde(default)]
+    unique: bool,
+}
+
+impl ContentLabels {
+    fn try_wrap<E>(self, content: Content) -> std::result::Result<Content, E>
+    where
+        E: serde::de::Error,
+    {
+        let mut output = content;
+
+        if self.unique {
+            output = output.into_unique();
+        }
+
+        if self.optional {
+            output = output.into_nullable();
+        }
+
+        Ok(output)
+    }
+}
+
+macro_rules! content {
+    {
+        labels: $labels:ty,
+        variants: {
+            $($name:ident($variant:ty)$(,)?)+
+        }
+    } => {
+        #[derive(Debug, Serialize, Clone, PartialEq)]
+        #[serde(rename_all = "snake_case")]
+        #[serde(tag = "type")]
+        #[serde(deny_unknown_fields)]
+        pub enum Content {
+            $($name($variant),)+
+        }
+
+        impl<'de> Deserialize<'de> for Content {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+            D: Deserializer<'de>,
+            {
+                #[derive(Deserialize)]
+                #[serde(rename_all = "snake_case")]
+                #[serde(tag = "type")]
+                #[serde(deny_unknown_fields)]
+                enum __Content {
+                    $($name($variant),)+
+                }
+
+                #[derive(Deserialize)]
+                struct __ContentWithLabels {
+                    #[serde(flatten)]
+                    labels: $labels,
+                    #[serde(flatten)]
+                    content: __Content
+                }
+
+                 struct Visitor;
+
+                impl<'de> serde::de::Visitor<'de> for Visitor {
+                    type Value = Content;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                        write!(formatter, "a general content node, a literal string starting with `@` (for a reference), or a JSON number (for a constant)")
+                    }
+
+                    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+                    where
+                    A: serde::de::MapAccess<'de>
+                    {
+                        use serde::de::MapAccess;
+                        use serde::de::IntoDeserializer;
+                        let mut out = HashMap::<String, serde_json::Value>::new();
+                        while let Some(key) = map.next_key()? {
+                            let value = map.next_value()?;
+                            out.insert(key, value);
+                        }
+                        let __ContentWithLabels { labels, content } = __ContentWithLabels::deserialize(out.into_deserializer()).map_err(A::Error::custom)?;
+                        match content {
+                            $(__Content::$name(inner) => {
+                                let inner_as_content = Content::$name(inner);
+                                labels.try_wrap(inner_as_content)
+                            },)+
+                        }
+                    }
+
+                    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+                    where
+                    E: serde::de::Error
+                    {
+                        Ok(Content::Number(number_content::U64::from(v).into()))
+                    }
+
+                    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+                    where
+                    E: serde::de::Error
+                    {
+                        Ok(Content::Number(number_content::I64::from(v).into()))
+                    }
+
+                    fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+                    where
+                    E: serde::de::Error
+                    {
+                        Ok(Content::Number(number_content::F64::from(v).into()))
+                    }
+
+                    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                    where
+                    E: serde::de::Error
+                    {
+                        if v.starts_with("@") {
+                            let ref_ = FieldRef::deserialize(v[1..].into_deserializer())?;
+                            let content = Content::SameAs(SameAsContent { ref_ });
+                            Ok(content)
+                        } else {
+                            Err(E::custom("string literals are synonymous to `same_as` and must start with `@` followed by the address of the referent"))
+                        }
+                    }
+                }
+
+                deserializer.deserialize_any(Visitor)
+            }
+        }
+    }
+}
+
+content! {
+    labels: ContentLabels,
+    variants: {
+        Null(NullContent),
+        Bool(BoolContent),
+        Number(NumberContent),
+        String(StringContent),
+        Array(ArrayContent),
+        Object(ObjectContent),
+        SameAs(SameAsContent),
+        OneOf(OneOfContent),
+        Series(SeriesContent),
+        Unique(UniqueContent),
+    }
 }
 
 impl Content {
     pub fn is_null(&self) -> bool {
-        matches!(self, Self::Null)
+        matches!(self, Self::Null(_))
+    }
+
+    pub fn null() -> Self {
+        Self::Null(NullContent)
+    }
+
+    pub fn as_nullable(&self) -> Option<&Self> {
+        match self {
+            Self::OneOf(one_of) => one_of.as_nullable(),
+            _ => None,
+        }
+    }
+
+    pub fn is_nullable(&self) -> bool {
+        self.as_nullable().is_some()
+    }
+
+    pub fn into_nullable(self) -> Self {
+        if !self.is_nullable() {
+            Content::OneOf(vec![self, Content::null()].into_iter().collect())
+        } else {
+            self
+        }
+    }
+
+    pub fn is_unique(&self) -> bool {
+        matches!(self, Self::Unique(_))
+    }
+
+    pub fn into_unique(self) -> Self {
+        if !self.is_unique() {
+            Content::Unique(UniqueContent {
+                algorithm: UniqueAlgorithm::default(),
+                content: Box::new(self),
+            })
+        } else {
+            self
+        }
     }
 
     pub fn accepts(&self, value: &Value) -> Result<()> {
@@ -130,7 +305,7 @@ impl Content {
             // self is a non-logical node
             _ => match value {
                 Value::Null => match self {
-                    Self::Null => Ok(()),
+                    Self::Null(_) => Ok(()),
                     _ => Err(failed!(
                         target: Release,
                         "expecting: '{}', found: 'null'",
@@ -185,7 +360,7 @@ impl Content {
 
     pub fn kind(&self) -> &'static str {
         match self {
-            Content::Null => "null",
+            Content::Null(_) => "null",
             Content::Bool(_) => "bool",
             Content::Number(_) => "number",
             Content::String(_) => "string",
@@ -201,7 +376,7 @@ impl Content {
 
 impl Default for Content {
     fn default() -> Self {
-        Self::Null
+        Self::Null(NullContent)
     }
 }
 
@@ -215,7 +390,7 @@ impl<'r> From<&'r Value> for Content {
     fn from(value: &'r Value) -> Self {
         match value {
             // TODO not sure what the correct behaviour is here
-            Value::Null => Content::Null,
+            Value::Null => Content::Null(NullContent),
             Value::Bool(_) => Content::Bool(BoolContent::default()),
             Value::String(_) => Content::String(StringContent::default()),
             Value::Array(arr) => {
@@ -229,9 +404,12 @@ impl<'r> From<&'r Value> for Content {
             Value::Object(obj) => {
                 let fields = obj
                     .iter()
-                    .map(|(key, value)| (key.to_string(), FieldContent::new(value)))
+                    .map(|(key, value)| (key.to_string(), Content::from(value)))
                     .collect();
-                Content::Object(ObjectContent { fields })
+                Content::Object(ObjectContent {
+                    fields,
+                    ..Default::default()
+                })
             }
             Value::Number(number_value) => {
                 let number_content = if number_value.is_f64() {
@@ -318,7 +496,7 @@ impl Compile for Content {
             Self::OneOf(one_of_content) => one_of_content.compile(compiler),
             Self::Series(series_content) => series_content.compile(compiler),
             Self::Unique(unique_content) => unique_content.compile(compiler),
-            Self::Null => Ok(Graph::null()),
+            Self::Null(_) => Ok(Graph::null()),
         }
     }
 }
@@ -372,6 +550,7 @@ pub mod tests {
     lazy_static! {
         pub static ref USER_SCHEMA: Content = from_json!({
             "type": "object",
+            "skip_when_null": true,
             "user_id": {
                 "type": "number",
                 "subtype": "u64",
@@ -384,6 +563,11 @@ pub mod tests {
             "type_": { // checks the underscore hack
                 "type": "string",
                 "pattern": "user|contributor|maintainer"
+            },
+            "skip_when_null_": {
+                "optional": true,
+                "type": "bool",
+                "frequency": 0.5
             },
             "first_name": {
                 "type": "string",

--- a/core/src/schema/content/number.rs
+++ b/core/src/schema/content/number.rs
@@ -154,6 +154,14 @@ macro_rules! number_content {
 		    )*
 		}
 
+        $(
+        impl From<$variant_ty> for $as {
+            fn from(value: $variant_ty) -> Self {
+                Self::$variant(value)
+            }
+        }
+        )*
+
 		impl From<$as> for NumberContent {
 		    fn from(value: $as) -> Self {
 			Self::$as(value)

--- a/core/src/schema/content/object.rs
+++ b/core/src/schema/content/object.rs
@@ -6,7 +6,7 @@ use serde::{
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 
-const RESERVED_FIELDS: [&'static str; 2] = ["type", "skip_when_null"];
+const RESERVED_FIELDS: [&str; 2] = ["type", "skip_when_null"];
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 pub struct ObjectContent {

--- a/core/src/schema/content/one_of.rs
+++ b/core/src/schema/content/one_of.rs
@@ -81,6 +81,25 @@ impl OneOfContent {
         }
     }
 
+    pub fn as_nullable(&self) -> Option<&Content> {
+        if self.variants.len() == 2 {
+            let mut non_null = self
+                .variants
+                .iter()
+                .filter(|variant| !variant.content.is_null())
+                .map(|vc| vc.content.as_ref());
+            let content = non_null.next()?;
+            if non_null.next().is_none() {
+                return Some(content);
+            }
+        }
+        None
+    }
+
+    pub fn is_nullable(&self) -> bool {
+        self.as_nullable().is_some()
+    }
+
     fn add_variant(&mut self, variant: Content) {
         self.variants.push(VariantContent::new(variant))
     }

--- a/core/src/schema/content/string.rs
+++ b/core/src/schema/content/string.rs
@@ -191,14 +191,6 @@ pub struct FormatContent {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[serde(rename_all = "lowercase")]
-#[serde(untagged)]
-pub enum ContentOrRef {
-    Content(Content),
-    FieldRef(FieldRef),
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct JsonContent {
     content: Box<Content>,
 }
@@ -503,7 +495,6 @@ pub mod datetime_content {
 }
 
 use crate::graph::string::Serialized;
-use crate::schema::FieldRef;
 pub use datetime_content::ChronoValueFormatter;
 
 impl Serialize for DateTimeContent {

--- a/core/src/schema/s_override.rs
+++ b/core/src/schema/s_override.rs
@@ -57,7 +57,7 @@ impl<'t> OverrideStrategy for DefaultOverrideStrategy<'t> {
 		variants.remove(idx);
 		Ok(())
 	    },
-	    Content::Object(ObjectContent { fields }) => {
+	    Content::Object(ObjectContent { fields, .. }) => {
 		fields
 		    .remove(&child)
 		    .ok_or_else(|| failed!(target: Release, "field '{}' not a member of '{}'", child, parent))?;

--- a/docs/docs/content/number.md
+++ b/docs/docs/content/number.md
@@ -34,6 +34,32 @@ A constant number type. This will always evaluate to the same number.
 }
 ```
 
+The constant number generator can also be simply declared by its desired output value.
+
+#### Example
+
+The schema
+
+```json synth
+{
+  "type": "object",
+  "just_the_number_42": 42
+}
+```
+
+is the same as the longer
+
+```json synth
+{
+  "type": "object",
+  "just_the_number_42": {
+    "type": "number",
+    "subtype": "u64",
+    "constant": 42
+  }
+}
+```
+
 ## id
 
 A monotonically increasing number type, most commonly used as a unique row identifier. The optional `start` field

--- a/docs/docs/content/object.md
+++ b/docs/docs/content/object.md
@@ -30,12 +30,29 @@ The keys of the JSON object to generate are inlined in the `object` keys (e.g. `
 Values of objects can be any of Synth's generator type (including an other object). In the example above, `"identifier"`
 has value a [`number`](/content/number) type and `"name"` has value a [`string`](/content/string) type.
 
-Values of objects can be made *optional* by specifying the `"optional": true` attribute.
+Values of objects can be made nullable by specifying the `"optional": true` attribute.
 
 #### Example
 ```json synth
 {
   "type": "object",
+  "email": {
+    "optional": true,
+    "type": "string",
+    "faker": {
+      "generator": "ascii_email"
+    }
+  }
+}
+```
+
+By default, optional values that are generated as `null` will produce a key-value pair of the form `key: null`. This behavior can be controlled by specifying the `skip_when_null: true` attribute on the object generator.
+
+#### Example
+```json synth
+{
+  "type": "object",
+  "skip_when_null": true,
   "email": {
     "optional": true,
     "type": "string",

--- a/docs/docs/content/same-as.md
+++ b/docs/docs/content/same-as.md
@@ -24,7 +24,7 @@ used to specify foreign key relationships in complex datasets.
 }
 ```
 
-The `"ref"` field must point to another existing field. Complex objects can be traversed by using concatenating levels
+The `"ref"` field must point to another existing field. Complex objects can be traversed by concatenating levels
 with a period `.`.
 
 #### Example
@@ -51,5 +51,29 @@ with a period `.`.
     "type": "same_as",
     "ref": "address.zip_code"
   }
+}
+```
+
+The `same_as` generator can also be simply declared by the value of the `"ref"` field prefixed with `@`:
+
+```json synth
+{
+  "type": "object",
+  "address": {
+    "type": "object",
+    "street_name": {
+      "type": "string",
+      "faker": {
+        "generator": "street_name"
+      }
+    },
+    "zip_code": {
+      "type": "string",
+      "faker": {
+        "generator": "zip_code"
+      }
+    }
+  },
+  "same_zip_code": "@address.zip_code"
 }
 ```

--- a/docs/docs/modifiers.md
+++ b/docs/docs/modifiers.md
@@ -1,0 +1,39 @@
+---
+slug: /modifiers
+title: Modifiers
+---
+
+Modifiers are attributes that can be added to any [generator](content/null) to modify their behavior.
+
+## `optional`
+
+The `optional` modifier makes a generator nullable. It accepts a single boolean value (true or false). 
+
+```json synth
+{
+  "type": "string",
+  "pattern": "hello|goodbye",
+  "optional": true
+}
+```
+
+## `unique`
+
+The `unique` modifiers ensures a generator only outputs non-repeating values. It accepts a single boolean value (true or false). 
+
+```json synth
+{
+  "type": "array",
+  "length": 10,
+  "content": {
+    "type": "number",
+    "subtype": "u64",
+    "unique": true,
+    "range": {
+      "low": 0,
+      "high": 20,
+      "step": 1
+    }
+  }
+}
+```

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -2,7 +2,7 @@ module.exports = {
     docsSidebar: {
         "Getting Started": ['getting_started/synth', 'getting_started/installation', 'getting_started/hello-world', 'getting_started/core-concepts', 'getting_started/schema', 'getting_started/command-line', 'getting_started/how-it-works'],
         "Examples": ['examples/bank'],
-        "Generators": ['content/null', 'content/bool', 'content/number', 'content/string', 'content/object', 'content/array', 'content/one-of', 'content/same-as', 'content/unique', 'content/series'],
+        "Generators": ['modifiers', 'content/null', 'content/bool', 'content/number', 'content/string', 'content/object', 'content/array', 'content/one-of', 'content/same-as', 'content/unique', 'content/series'],
         "Other": ['other/telemetry']
     },
 };

--- a/synth/src/cli/mongo.rs
+++ b/synth/src/cli/mongo.rs
@@ -15,8 +15,8 @@ use synth_core::graph::prelude::number_content::I64;
 use synth_core::graph::prelude::{NumberContent, ObjectContent, RangeStep};
 use synth_core::schema::number_content::F64;
 use synth_core::schema::{
-    ArrayContent, BoolContent, Categorical, ChronoValueType, DateTimeContent, FieldContent,
-    OneOfContent, RegexContent, StringContent,
+    ArrayContent, BoolContent, Categorical, ChronoValueType, DateTimeContent, OneOfContent,
+    RegexContent, StringContent,
 };
 use synth_core::{Content, Name, Namespace};
 
@@ -106,10 +106,13 @@ fn doc_to_content(doc: &Document) -> Content {
 
     // Notice this `filter` here is a hack as we don't support id's out of the box.
     for (name, bson) in doc.iter().filter(|(name, _)| name.as_str() != "_id") {
-        let fc = FieldContent::new(bson_to_content(bson));
-        root.insert(name.clone(), fc);
+        let content = bson_to_content(bson);
+        root.insert(name.clone(), content);
     }
-    Content::Object(ObjectContent { fields: root })
+    Content::Object(ObjectContent {
+        fields: root,
+        ..Default::default()
+    })
 }
 
 fn bson_to_content(bson: &Bson) -> Content {
@@ -131,7 +134,7 @@ fn bson_to_content(bson: &Bson) -> Content {
         }
         Bson::Document(doc) => doc_to_content(doc),
         Bson::Boolean(_) => Content::Bool(BoolContent::Categorical(Categorical::default())),
-        Bson::Null => Content::Null,
+        Bson::Null => Content::null(),
         Bson::RegularExpression(regex) => Content::String(StringContent::Pattern(
             RegexContent::pattern(regex.pattern.clone()).unwrap_or_default(),
         )),

--- a/synth/src/cli/mongo.rs
+++ b/synth/src/cli/mongo.rs
@@ -8,14 +8,13 @@ use mongodb::{bson::Document, options::ClientOptions, sync::Client};
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::convert::TryInto;
-use std::iter::FromIterator;
 use std::str::FromStr;
 use synth_core::graph::prelude::content::number_content::U64;
 use synth_core::graph::prelude::number_content::I64;
 use synth_core::graph::prelude::{NumberContent, ObjectContent, RangeStep};
 use synth_core::schema::number_content::F64;
 use synth_core::schema::{
-    ArrayContent, BoolContent, Categorical, ChronoValueType, DateTimeContent, OneOfContent,
+    ArrayContent, BoolContent, Categorical, ChronoValueType, DateTimeContent,
     RegexContent, StringContent,
 };
 use synth_core::{Content, Name, Namespace};
@@ -129,7 +128,7 @@ fn bson_to_content(bson: &Bson) -> Content {
 
             Content::Array(ArrayContent {
                 length: Box::new(length),
-                content: Box::new(Content::OneOf(OneOfContent::from_iter(content_iter))),
+                content: Box::new(Content::OneOf(content_iter.collect())),
             })
         }
         Bson::Document(doc) => doc_to_content(doc),


### PR DESCRIPTION
This
* Re-defines the deserialization of `Content` to support deserializing from literals in the following instances:
    * String literals are interpreted as `Content::SameAs` (i.e. references)
    * Number literals are interpreted as `Constant` `Content::Number` variants
* Removes `FieldContent`
    * The only purpose of `FieldContent` was to allow for the field `optional: bool` to be available in `Content::Object`'s fields. This is now taken care of by `schema::content::ContentLabels`. The change was required because deserialization of `FieldContent` was incompatible with the specification of references as string literals.
* In order to preserve backward compat, the new deserialize impl also allows for the specification of the `optional: bool` and `unique: bool` fields on any Content node.
    * It works by implicitly wrapping the Content in a `OneOf` or `Unique` variant, making the JSON schema simpler in addition to preserving backward compat
* Add a `skip_when_null` field attribute to `Content::Object` variant in order to expose the choice to the user of serializing nullable fields as `key: null` or by skipping the key/value pair altogether. The default is `false`, i.e. `null` fields are generated as `key: null`.
    * This also extends the "underscore hack" to this new field `skip_when_null` so that users can, if necessary, have a `skip_when_null` field in the generated data by specifying it as `skip_when_null_` in the JSON schema.

