### PR TITLE
perf: optimize anyhow usage to lazily allocate heap memory

### DIFF
--- a/core/src/compile/mod.rs
+++ b/core/src/compile/mod.rs
@@ -589,7 +589,7 @@ impl<'a> NamespaceCompiler<'a> {
             stage_2!("{}: building", next_scope);
             let mut model = content_compiler
                 .compile()
-                .context(format!("at `{}`", &next_scope))?;
+                .with_context(|| format!("at `{}`", &next_scope))?;
             stage_2!("{}: done", next_scope);
 
             if let Ok(locals) = self.vtable.get(&next_scope) {
@@ -937,7 +937,7 @@ where
         let (root, relative_what) = what.relativize(&to);
         let relative_to = to.as_in(&root).unwrap();
         self.get_mut(&root)
-            .context(anyhow!(
+            .with_context(|| anyhow!(
                 "looking for the common root to {} and {}",
                 what,
                 to

--- a/core/src/schema/augmentation.rs
+++ b/core/src/schema/augmentation.rs
@@ -38,7 +38,7 @@ impl AugmentationApi for Namespace {
         match self.get_s_node_mut(&parent) {
             Ok(parent_node) => parent_node
                 .augment(augmentation.field.last(), augmentation.augmentation)
-                .context(format!("at field: {}", parent)),
+                .with_context(|| format!("at field: {}", parent)),
             Err(_) => self.augment_with_ancestors(
                 &parent,
                 vec![augmentation.field.last()],
@@ -57,7 +57,7 @@ impl AugmentationApi for Namespace {
         let parent_node = self.get_s_node_mut(&parent)?;
         parent_node
             .delete_child(field.last())
-            .context(format!("at field: {}", parent))
+            .with_context(|| format!("at field: {}", parent))
     }
 }
 

--- a/core/src/schema/content/object.rs
+++ b/core/src/schema/content/object.rs
@@ -97,7 +97,7 @@ impl ObjectContent {
                     .ok_or_else(|| failed!(target: Release, "could not find field: '{}'", k))?;
                 v.content
                     .accepts(json_value)
-                    .context(anyhow!("in a field: '{}'", k))?;
+                    .with_context(|| anyhow!("in a field: '{}'", k))?;
             }
         }
 
@@ -173,7 +173,7 @@ impl Find<Content> for ObjectContent {
         self.get(next)?
             .content
             .project(reference)
-            .context(anyhow!("in a field: {}", next))
+            .with_context(|| anyhow!("in a field: {}", next))
     }
 
     fn project_mut<I, R>(&mut self, mut reference: Peekable<I>) -> Result<&mut Content>
@@ -188,7 +188,7 @@ impl Find<Content> for ObjectContent {
         self.get_mut(next)?
             .content
             .project_mut(reference)
-            .context(anyhow!("in a field named {}", next))
+            .with_context(|| anyhow!("in a field named {}", next))
     }
 }
 

--- a/core/src/schema/inference/value.rs
+++ b/core/src/schema/inference/value.rs
@@ -127,7 +127,7 @@ impl MergeStrategy<Object, Object> for ValueMergeStrategy {
                 if let Some(field) = master.get_mut(key) {
                     debug!("try_merge entering '{}'", key);
                     self.try_merge(field, value)
-                        .context(anyhow!("in a field: {}", key))?;
+                        .with_context(|| anyhow!("in a field: {}", key))?;
                 } else {
                     master.insert(key.clone(), value.clone());
                 }

--- a/core/src/schema/namespace.rs
+++ b/core/src/schema/namespace.rs
@@ -133,14 +133,14 @@ impl Namespace {
         let collection = reference.collection();
         self.get_collection_mut(collection)?
             .find_mut(reference.iter_fields().peekable())
-            .context(format!("in a collection: '{}'", collection))
+            .with_context(|| format!("in a collection: '{}'", collection))
     }
 
     pub fn get_s_node(&self, reference: &FieldRef) -> Result<&Content> {
         let collection = reference.collection();
         self.get_collection(collection)?
             .find(reference.iter_fields().peekable())
-            .context(format!("in a collection: '{}'", collection))
+            .with_context(|| format!("in a collection: '{}'", collection))
     }
 
     pub fn get_collection_mut(&mut self, name: &Name) -> Result<&mut Content> {

--- a/synth/src/cli/export.rs
+++ b/synth/src/cli/export.rs
@@ -111,5 +111,5 @@ fn insert_data<T: DataSource>(datasource: &T, collection_name: String, collectio
             collection_name.clone(),
             collection_json
         )
-    ).context(format!("Failed to insert data for collection {}", collection_name))
+    ).with_context(|| format!("Failed to insert data for collection {}", collection_name))
 }

--- a/synth/src/cli/import.rs
+++ b/synth/src/cli/import.rs
@@ -122,7 +122,7 @@ fn ns_from_value(value: Value) -> Result<Namespace> {
             .map(|(name, value)| {
                 collection_from_value(&value)
                     .and_then(|content| Ok((name.parse()?, content)))
-                    .context(anyhow!("While importing the collection `{}`", name))
+                    .with_context(|| anyhow!("While importing the collection `{}`", name))
             })
             .collect(),
         unacceptable => Err(anyhow!(

--- a/synth/src/cli/import_utils.rs
+++ b/synth/src/cli/import_utils.rs
@@ -21,7 +21,7 @@ struct FieldContentWrapper(FieldContent);
 pub(crate) fn build_namespace_import<T: DataSource + RelationalDataSource>(datasource: &T)
     -> Result<Namespace> {
     let table_names = task::block_on(datasource.get_table_names())
-        .context(format!("Failed to get table names"))?;
+        .with_context(|| format!("Failed to get table names"))?;
 
     let mut namespace = Namespace::default();
 

--- a/synth/src/cli/mod.rs
+++ b/synth/src/cli/mod.rs
@@ -131,14 +131,14 @@ impl Cli {
             }
             false => {
                 let workspace_dir = ".synth";
-                let result = std::fs::create_dir_all(base_path.join(workspace_dir)).context(format!(
+                let result = std::fs::create_dir_all(base_path.join(workspace_dir)).with_context(|| format!(
                     "Failed to create working directory at: {} during initialization",
                     base_path.join(workspace_dir).to_str().unwrap()
                 ));
                 let config_path = ".synth/config.toml";
                 match result {
                     Ok(()) => {
-                        File::create(base_path.join(config_path)).context(format!(
+                        File::create(base_path.join(config_path)).with_context(|| format!(
                             "Failed to create config file at: {} during initialization",
                             base_path.join(config_path).to_str().unwrap()
                         ))?;
@@ -148,7 +148,7 @@ impl Cli {
                         if e.downcast_ref::<std::io::Error>().unwrap().kind()
                             == std::io::ErrorKind::AlreadyExists =>
                     {
-                        File::create(base_path.join(config_path)).context(format!(
+                        File::create(base_path.join(config_path)).with_context(|| format!(
                             "Failed to initialize workspace at: {}. File already exists.",
                             base_path.join(config_path).to_str().unwrap()
                         ))?;
@@ -243,7 +243,7 @@ impl Cli {
 
         to.unwrap_or_default()
             .export(params)
-            .context(format!("At namespace {:?}", ns_path))
+            .with_context(|| format!("At namespace {:?}", ns_path))
     }
 }
 

--- a/synth/src/cli/store.rs
+++ b/synth/src/cli/store.rs
@@ -35,7 +35,7 @@ impl Store {
     pub fn init() -> Result<Self> {
         Ok(Self {
             path: std::env::current_dir()
-                .context(failed!(target: Debug, "Failed to initialise the store"))?,
+                .with_context(|| failed!(target: Debug, "Failed to initialise the store"))?,
         })
     }
 
@@ -74,14 +74,14 @@ impl Store {
 
         for entry in ns_path
             .read_dir()
-            .context(format!("At path {:?}", ns_path))?
+            .with_context(|| format!("At path {:?}", ns_path))?
         {
             let entry = entry?;
             if let Some(file_ext) = entry.path().extension() {
                 if file_ext == UNDERLYING.extension() {
                     let (collection_name, content) = self
                         .get_collection(&entry)
-                        .context(anyhow!("at file {}", entry.path().display()))?;
+                        .with_context(|| anyhow!("at file {}", entry.path().display()))?;
                     ns.put_collection(&collection_name, content)?;
                 }
             }

--- a/synth/src/daemon.rs
+++ b/synth/src/daemon.rs
@@ -288,7 +288,7 @@ impl Daemon {
         strategy.merge(&mut namespace, &req.body.override_)?;
 
         self.validate(&namespace)
-            .context(anyhow!("while validating the overridden model"))?;
+            .with_context(|| anyhow!("while validating the overridden model"))?;
 
         namespace.commit()?;
         Ok(PutOverrideResponse {})
@@ -324,7 +324,7 @@ impl Daemon {
             if !namespace.collection_exists(&collection) {
                 namespace
                     .create_collection(&collection, document)
-                    .context(anyhow!(
+                    .with_context(|| anyhow!(
                         "while creating a collection from the first document"
                     ))?;
             }
@@ -339,7 +339,7 @@ impl Daemon {
 
             let as_value = Value::from(documents);
             namespace.try_update(OptionalMergeStrategy, &collection, &as_value)?;
-            self.validate(namespace.as_ref()).context(anyhow!(
+            self.validate(namespace.as_ref()).with_context(|| anyhow!(
                 "while validating the inferred model prior to persisting it"
             ))?;
 

--- a/synth/src/index.rs
+++ b/synth/src/index.rs
@@ -152,7 +152,7 @@ impl Index {
         let _lock = self
             .store
             .lock_exclusive(ns_entry.lock_path())
-            .context(anyhow!(
+            .with_context(|| anyhow!(
                 "while acquiring a shared lock on the namespace: {}",
                 ns_name
             ))?;
@@ -160,7 +160,7 @@ impl Index {
         let old_ns = self
             .store
             .get(ns_entry.at_generation(gen))
-            .context(anyhow!(
+            .with_context(|| anyhow!(
                 "while retrieving schema generation '{}' for namespace '{}'",
                 gen,
                 ns_entry.namespace
@@ -196,14 +196,14 @@ impl Index {
         let lock = self
             .store
             .lock_shared(ns_entry.lock_path())
-            .context(anyhow!(
+            .with_context(|| anyhow!(
                 "while acquiring a shared lock on the namespace: {}",
                 ns_entry.namespace
             ))?;
         let ns: Namespace = self
             .store
             .get(ns_entry.at_generation(gen))
-            .context(anyhow!(
+            .with_context(|| anyhow!(
                 "while retrieving schema for namespace '{}'",
                 &ns_entry.namespace,
             ))?;
@@ -215,11 +215,11 @@ impl Index {
         let lock = self
             .store
             .lock_exclusive(ns_entry.lock_path())
-            .context(anyhow!(
+            .with_context(|| anyhow!(
                 "while acquiring an exclusive lock on the namespace: {}",
                 ns_name
             ))?;
-        let ns: Namespace = self.store.get(ns_entry.generation_path()).context(anyhow!(
+        let ns: Namespace = self.store.get(ns_entry.generation_path()).with_context(|| anyhow!(
             "while retrieving schema for namespace '{}'",
             ns_name,
         ))?;


### PR DESCRIPTION
Replace most of anyhow's Context::context by Context::with_context in order to only allocate heap memory when necessary.