### PR TITLE
fix: changed to use os independent paths 

### DIFF
--- a/.github/workflows/synth-test.yml
+++ b/.github/workflows/synth-test.yml
@@ -12,7 +12,10 @@ on:
 
 jobs:
   cargo_test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/synth/src/cli/mod.rs
+++ b/synth/src/cli/mod.rs
@@ -135,12 +135,12 @@ impl Cli {
                     "Failed to create working directory at: {} during initialization",
                     base_path.join(workspace_dir).to_str().unwrap()
                 ));
-                let config_path = ".synth/config.toml";
+                let config_path = self.get_synth_config_file(base_path);
                 match result {
                     Ok(()) => {
-                        File::create(base_path.join(config_path)).with_context(|| format!(
+                        File::create(config_path.as_path()).with_context(|| format!(
                             "Failed to create config file at: {} during initialization",
-                            base_path.join(config_path).to_str().unwrap()
+                            config_path.to_str().unwrap()
                         ))?;
                         Ok(())
                     }
@@ -148,9 +148,9 @@ impl Cli {
                         if e.downcast_ref::<std::io::Error>().unwrap().kind()
                             == std::io::ErrorKind::AlreadyExists =>
                     {
-                        File::create(base_path.join(config_path)).with_context(|| format!(
+                        File::create(config_path.as_path()).with_context(|| format!(
                             "Failed to initialize workspace at: {}. File already exists.",
-                            base_path.join(config_path).to_str().unwrap()
+                            config_path.to_str().unwrap()
                         ))?;
                         Ok(())
                     }
@@ -160,12 +160,16 @@ impl Cli {
         }
     }
 
+    fn get_synth_config_file(&self, base_path: PathBuf) -> PathBuf {
+        base_path.join(".synth").join("config.toml")
+    }
+
     fn workspace_initialised(&self) -> bool {
-        Path::new(".synth/config.toml").exists()
+        PathBuf::from(".synth").join("config.toml").exists()
     }
 
     fn workspace_initialised_from_path(&self, init_path: &PathBuf) -> bool {
-        let config_path = init_path.join(".synth/config.toml");
+        let config_path = init_path.join(".synth").join("config.toml");
         Path::new(&config_path).exists()
     }
 

--- a/synth/src/cli/mod.rs
+++ b/synth/src/cli/mod.rs
@@ -321,6 +321,9 @@ pub enum TelemetryCommand {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use std::env::temp_dir;
+    use crate::{META_OS, version};
+    use std::fs;
 
     #[test]
     fn test_derive_seed() {
@@ -328,5 +331,23 @@ pub mod tests {
         assert_eq!(Cli::derive_seed(false, Some(5)).unwrap(), 5);
         assert!(Cli::derive_seed(true, Some(5)).is_err());
         assert!(Cli::derive_seed(true, None).is_ok());
+    }
+
+    #[test]
+    fn test_init() {
+        let mut temp_dir = temp_dir();
+        temp_dir.push("synth_test_init");
+
+        // Some environments have temp dir related env vars set, making it sticky (i.e., $TMPDIR).
+        // Remove the contents from previous runs, if needed.
+        if temp_dir.exists() {
+            fs::remove_dir_all(&temp_dir).unwrap();
+            fs::create_dir(&temp_dir).unwrap();
+        }
+
+        let args = CliArgs::Init { init_path: Some(temp_dir.clone()) };
+        let cli = Cli::new(args, version(), META_OS.to_string())
+            .unwrap();
+        assert!(cli.init(Some(temp_dir)).is_ok())
     }
 }

--- a/synth/src/cli/telemetry.rs
+++ b/synth/src/cli/telemetry.rs
@@ -46,7 +46,7 @@ impl TelemetryConfig {
             "Could not find a configuration directory. Your operating system may not be supported."
         )
         })?;
-        Ok(synth_config_dir.join("synth/"))
+        Ok(synth_config_dir.join("synth"))
     }
 
     fn file_path() -> Result<PathBuf> {

--- a/synth/src/index.rs
+++ b/synth/src/index.rs
@@ -58,15 +58,15 @@ impl NamespaceEntry {
     }
 
     fn at_generation(&self, gen: i32) -> PathBuf {
-        format!("{}/{}", self.namespace, gen).into()
+        self.namespace_path().join(gen)
     }
 
     fn namespace_path(&self) -> PathBuf {
-        format!("{}/", self.namespace).into()
+        PathBuf::from(self.namespace.as_str())
     }
 
     fn lock_path(&self) -> PathBuf {
-        format!("{}/.lock", self.namespace).into()
+        self.namespace_path().join(".lock")
     }
 
     fn update(&self) -> Self {

--- a/synth/src/store.rs
+++ b/synth/src/store.rs
@@ -204,7 +204,10 @@ pub mod tests {
         let store = FileStore::new(dir.path().into()).unwrap();
 
         store.init(&namespace_name).unwrap();
-        let lock = store.lock_exclusive(&namespace_name).unwrap();
+
+        let mut lock_file_path = PathBuf::from(namespace_name);
+        lock_file_path.push(".lock");
+        let lock = store.lock_exclusive(&lock_file_path).unwrap();
 
         let struct_ref = "some_ns/some_struct".parse::<OsString>().unwrap();
         let some_struct = TestStruct {

--- a/tools/vagrant/windows/win10/Vagrantfile
+++ b/tools/vagrant/windows/win10/Vagrantfile
@@ -1,0 +1,29 @@
+PROJECT_SRC_DIR = "/synth"
+PROJECT_SRC_WIN_DIR = "C:\\synth"
+PROJECT_SRC_SANDBOX_WIN_DIR = "C:\\synth-sandbox"
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "gusztavvargadr/windows-10"
+
+  config.vm.provider :virtualbox do |v, override|
+    v.customize ["modifyvm", :id, "--memory", "4096"]
+    v.customize ["modifyvm", :id, "--cpus", "2"]
+    v.customize ["modifyvm", :id, "--vram", 32]
+    v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+    v.customize ["modifyvm", :id, "--audio", "none"]
+    v.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
+    v.customize ["modifyvm", :id, "--draganddrop", "hosttoguest"]
+    v.customize ["modifyvm", :id, "--usb", "off"]
+    v.customize ["modifyvm", :id, "--nested-hw-virt", "on"]
+    v.linked_clone = true if Vagrant::VERSION >= '1.8.0'
+  end
+
+  config.vm.guest = :windows
+  config.vm.communicator = "winrm"
+  config.vm.network "forwarded_port", guest: 3389, host: 3389
+
+  config.vm.synced_folder "../../../../", PROJECT_SRC_WIN_DIR
+  config.vm.provision "shell",
+      inline: "Copy-Item -Path $Args[0] -Recurse -Destination $Args[1] -Container",
+      args: [PROJECT_SRC_WIN_DIR, PROJECT_SRC_SANDBOX_WIN_DIR]
+end


### PR DESCRIPTION
- Changed file paths to use OS independent separators
- Added `Vagrantfile` for Windows 10
- Fixed test_e2e specifying wrong lock file
- Add synth init test
- Added OS matrix testing for `synth-test.yml`
Addresses #73 