### PR TITLE
bench only on push

### DIFF
--- a/.github/workflows/synth-bench.yml
+++ b/.github/workflows/synth-bench.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches: [ master ]
     paths: [ '**/*.rs', '.github/workflows/synth-bench.yml' ]
-  pull_request:
-    branches: [ master ]
-    paths: [ '**/*.rs', '.github/workflows/synth-bench.yml' ]
-
-  workflow_dispatch:
 
 env:
   BENCHPATH: /home/runner/work/synth/synth/synth


### PR DESCRIPTION
This should sidestep the problem of 403 errors on comment right now while
we figure out a suitable workaround.