### PR TITLE
docs: Typos, housekeep

### DIFF
--- a/docs/blog/2021-03-09-postgres-data-gen.md
+++ b/docs/blog/2021-03-09-postgres-data-gen.md
@@ -120,7 +120,7 @@ We could define functions ourselves to generate names / phone numbers / emails e
 
 [Synth](https://github.com/getsynth/synth) is an open-source project designed to solve the problem of creating realistic testing data. It has integration with Postgres, so you won't need to write any SQL.
 
-Synth uses declarative configuration files (just JSON don't worry) to define how data should be generated. To install the `synth` binary refer to the [installation page](https://getsynth.github.io/synth/getting_started/installation).
+Synth uses declarative configuration files (just JSON don't worry) to define how data should be generated. To install the `synth` binary refer to the [installation page](/getting_started/installation).
 
 The first step to use Synth is to create a workspace. A workspace is just a directory in your filesystem that tell Synth that this is where you are going to be storing configuration:
 
@@ -181,7 +181,7 @@ $ synth generate my_app/ --size 2
 }
 ```
 
-Now we can do the same thing for the `contacts` table by create a file `my_app/contacts.json`. Here we have the added complexity of a foreign key constraints to the company table, but we can solve it easily using Synth's [`same_as`](https://getsynth.github.io/synth/content/same-as/) generator.
+Now we can do the same thing for the `contacts` table by create a file `my_app/contacts.json`. Here we have the added complexity of a foreign key constraints to the company table, but we can solve it easily using Synth's [`same_as`](/content/same-as) generator.
 
 
 ```json

--- a/docs/docs/content/array.md
+++ b/docs/docs/content/array.md
@@ -2,7 +2,7 @@ Synth's `array` type mirrors JSON's arrays. An `array` type requires the followi
 
 - `"content"`: specifies the elements of the generated array. Allowed value is any of Synth's generator type.
 - `"length"`: specifies the length of the generated array. Allowed value is any of
-  Synth's [`number`](/synth/content/number) type with `"subtype": "u64"`.
+  Synth's [`number`](/content/number) type with `"subtype": "u64"`.
 
 The example below generates arrays of credit card numbers with `3` to `10` elements.
 

--- a/docs/docs/content/object.md
+++ b/docs/docs/content/object.md
@@ -28,7 +28,7 @@ The keys of the JSON object to generate are inlined in the `object` keys (e.g. `
 ```
 
 Values of objects can be any of Synth's generator type (including an other object). In the example above, `"identifier"`
-has value a [`number`](/synth/content/number) type and `"name"` has value a [`string`](/synth/content/string) type.
+has value a [`number`](/content/number) type and `"name"` has value a [`string`](/content/string) type.
 
 Values of objects can be made *optional* by specifying the `"optional": true` attribute.
 

--- a/docs/docs/content/one-of.md
+++ b/docs/docs/content/one-of.md
@@ -3,7 +3,7 @@ title: one_of
 ---
 Synth's `one_of` generator is a compound operator, i.e. a way to compose other generator types together. It lets you
 define a new generator that samples randomly from a specified list of dependent generators (called *variants*). In that
-way, `one_of` is similar to [categorical `string`s](/synth/content/string#categorical). However, the variants of
+way, `one_of` is similar to [categorical `string`s](/content/string#categorical). However, the variants of
 a `one_of` generator are allowed to be generated from any other Synth generator.
 
 Variants of a `one_of` generator are specified with the `"variants"` field. Allowed value is an array of Synth

--- a/docs/docs/content/same-as.md
+++ b/docs/docs/content/same-as.md
@@ -3,7 +3,7 @@ title: same_as
 ---
 
 Synth's `same_as` generator type establishes a relation between two generators. It lets you re-use a value generated at
-a different level in say, an [`object`](/synth/content/object), at a different level in the same object. It is often
+a different level in say, an [`object`](/content/object), at a different level in the same object. It is often
 used to specify foreign key relationships in complex datasets.
 
 #### Example

--- a/docs/docs/examples/bank.md
+++ b/docs/docs/examples/bank.md
@@ -167,7 +167,6 @@ $ tree -a
 │   ├── transactions.json
 │   └── users.json
 └── .synth
-    └── config.toml
 ```
 
 The directory `bank_db` (remember from [Core Concepts](/getting_started/core-concepts) a subdirectory in a workspace represents a

--- a/docs/docs/getting_started/cli.md
+++ b/docs/docs/getting_started/cli.md
@@ -1,9 +1,9 @@
 ---
 id: command-line
-title: Synth CLI
+title: Command-line
 ---
 
-The Synth CLI (`synth`) is a Unix-y command line tool wrapped around the core synthetic data engine. 
+`synth` is a Unix-y command line tool wrapped around the core synthetic data engine. 
 
 ## Usage
 
@@ -12,7 +12,6 @@ The Synth CLI (`synth`) is a Unix-y command line tool wrapped around the core sy
 ### Command: init
 
 Usage: `synth init`
-
 
 This is the first command that should be run for any new or existing when starting out with Synth. 
 This initialises the workspace and  sets up all the local data necessary to run Synth.
@@ -31,18 +30,23 @@ Synth can create namespaces from different data sources using the `synth import`
 Accidentally running `synth import` on an existing namespace is safe - the operation will fail.
 
 If a subdirectory for a given namespace does not exist in your workspace, Synth will create it.
-    
 
+#### Argument
+
+- `<namespace>` - The desired path to the imported namespace directory. Can only
+  be a path relative to the current (initialised) workspace root.
+  
 #### Options
-
+ 
 - `--from <from>` - The location from which to import. Synth supports multiple import strategies. 
   
   Importing from a file: Currently we support importing from JSON files by specifying the path to
                            the file: `/some/path/to/file.json`.
   
   Importing from standard input: Not specifying `from` will accept JSON files from stdin.
-  
-  Importing from a database (e.g. postgres): synth import tpch --from postgres://user:pass@localhost:5432/tpch
+
+  Importing from a database (e.g.
+  postgres): `synth import tpch --from postgres://user:pass@localhost:5432/tpch`
 
 ---
 
@@ -52,26 +56,17 @@ Usage: `synth generate [OPTIONS] <namespace>`
 
 The `synth generate` command will generate data for a given namespace. This will not mutate anything in the underlying configuration.
 
-If there is a misconfiguration in your schema (for example referring to a field that does not exist), `synth generate` will exit with a non-zero exit code and hopefully some error message helping you understand which part of the schema is misconfigured.
+If there is a misconfiguration in your schema (for example referring to a field that does not exist), `synth generate` will exit with a non-zero exit code and output an error message to help you understand which part of the schema is misconfigured.
 
+#### Argument
+
+- `<namespace>` - The path to the namespace you wish to generate data for. Can
+  only be a path relative to the current (initialised) workspace root.
+  
 #### Options
 
-- `--collection <collection>` - Specify a specific collection in a namespace if you don't want to generate data from all collections.  
+- `--collection <collection>` - Specify a specific collection in a namespace if you don't want to generate data from all collections.
 - `--size <size>` - The number of elements which should be generated per collection. This number is not guaranteed, it serves as a lower bound.
 - `--to <uri>` - The generation destination. If unspecified, generation defaults to stdout.
 - `--seed <seed>` - An unsigned 64 bit integer seed to be used as a seed for generation. Defaults to 0 if unspecified.
 - `--random` - A flag which toggles generation with a random seed. This cannot be used with --seed.
----
-
-### Command: serve
-
-Usage: `synth serve [OPTIONS]`
-
-Run Synth in Daemon mode. The Daemon exposes an HTTP RESTful API on port `8182` and creates an internal state which is managed by a version controlled index.
-                            
-Daemon mode is used when `synth` is used in the context of a collaborating team and comes with a very handy [Python client](https://getsynth.github.io/synthpy/)
-
-#### Options
-
-- `-b, --bind <bind> [default: 0.0.0.0:8182]` - The endpoint on which the HTTP server should be exposed.  
-- `-d, --data-directory <data-directory> [default: <workspace>/.synth/]` - The directory which should host the index. (Default is fine in the context of a workspace)

--- a/docs/docs/getting_started/hello-world.md
+++ b/docs/docs/getting_started/hello-world.md
@@ -2,8 +2,9 @@
 title: Hello world
 ---
 
-After installing the Synth CLI, the next step is to create a *workspace*. Workspaces are directories in your filesystem
-that Synth uses to read your schemas from.
+After installing [`synth`][synth], the next step is to create a **workspace**. 
+
+Workspaces are directories in your filesystem that [`synth`][synth] uses to read your schemas from. Currently [`synth`][synth] reads schemas written in a specialized JSON data model. You can find out everything there is to know about [`synth`][synth] schemas in the [Generators][generators] section or in the [Schema][schema] section. In this section we will show you how to set up a simple "hello world" data generator.
 
 To create and initialise a workspace called `synth_workspace` in your current working directory, run:
 
@@ -13,20 +14,22 @@ mkdir synth_workspace && cd synth_workspace && synth init
 
 :::note Note
 
-The command `synth init` creates a marker directory called `.synth` in your present working directory. This marker
-directory acts as simply an anchor to tell Synth that this is a workspace.
+The command [`synth init`][synth-init] creates a marker directory called `.synth` in the directory where it is run. This marker directory acts as simply an anchor to tell [`synth`][synth] that this is a workspace.
 :::
 
-Next we need to create a *namespace*. Namespaces are collections of schema files which are allowed to refer to one
-another. They are organized simply by creating directories in your workspace. Let's create a namespace
-called `my_namespace`:
+Next we need to create a **namespace**. Namespaces are directories in an
+initialized [`synth`][synth] workspace. All the schema files in a given
+namespace are collated and compiled together at runtime.
+
+Let's create a namespace called `my_namespace`:
 
 ```bash
 mkdir my_namespace
 ```
 
-Finally, we need to add a *collection* to our namespace. Collections are JSON files which describe the "shape" of the
-data we want to generate. They follow the Synth [schemas][schema] format.
+Finally, we need to add a **collection** to our namespace. Collections describe
+the "shape" of the data we want to generate. They are individual JSON files
+within a namespace written according to the [`synth` schema][generators].
 
 To create a collection called "dummy" in our namespace, simply copy/paste the content of the following example in a file
 at `synth_workspace/my_namespace/dummy.json`:
@@ -46,21 +49,26 @@ at `synth_workspace/my_namespace/dummy.json`:
 }
 ```
 
-The previous example snippet is an example of the Synth [schema][schema] format. All the examples of the
-Synth [schema][schema] in these documentation pages are tagged with a "**Run**" button that lets you preview Synth
-output data when you click it.
+The previous example snippet is an example of
+a [`synth` schema][schema]. All such examples in these pages
+are tagged with a "**Run**"
+button that lets you preview how [`synth`][synth] would output the corresponding
+data.
 
 Finally, run
 ```bash
 synth generate my_namespace/
 ```
-and you should see an output very close to the output of the above snippet.
+and you should see an output very close to the output of the snippet.
 
 ## Where to go from here
-* Take a look at the exhaustive [generators reference](/content/null.md).
-* Go into how Synth works by looking at the [core concepts][core-concepts] and the Synth [schema][schema] format.
+* Take a look at the exhaustive [generators reference][generators].
+* Go deeper into how [`synth`][synth] works by looking at the [core concepts][core-concepts] and the specifications of the [schema][schema].
 * For more complex real life examples, see the [examples][examples] section.
 
+[synth]: cli.md
+[synth-init]: cli.md#command-init
 [schema]: schema.md
+[generators]: /content/object.md
 [core-concepts]: core-concepts.md
-[examples]: examples/bank.md
+[examples]: /examples/bank.md

--- a/docs/docs/getting_started/installation.md
+++ b/docs/docs/getting_started/installation.md
@@ -25,13 +25,13 @@ To skip the telemetry prompt (if you are installing Synth in CI for example) you
 
 <TabItem value='windows'>
 
-To install on Windows, [download](https://github.com/getsynth/synth/releases/latest/download/synth-windows-latest-x86_64.exe) the Synth executable and run it from your `cmd` or `Git BASH` or `Windows PowerShell`.
+To install on Windows, [download](https://github.com/getsynth/synth/releases/latest/download/synth-windows-latest-x86_64.exe) the `synth` executable and run it from your `cmd` or `Git BASH` or `Windows PowerShell`.
 
-Then copy the downloaded executable to a suitable folder (e.g. C:\synth\synth.exe).
+Then copy the downloaded executable to a suitable folder (e.g. `C:\synth\synth.exe`).
 
-Finally - [add Synth to your PATH](https://www.architectryan.com/2018/03/17/add-to-the-path-on-windows-10/) via your environment variables.
+Finally [add `synth` to your PATH](https://www.architectryan.com/2018/03/17/add-to-the-path-on-windows-10/) via your environment variables.
 
-You should now be able to use synth:
+You should now be able to use `synth`:
 
 ```
 PS C:\Users\user\workspace> synth --version

--- a/docs/docs/getting_started/synth.md
+++ b/docs/docs/getting_started/synth.md
@@ -23,9 +23,9 @@ The key features of Synth are:
 - **Data as Code**: Data generation is described using a declarative configuration language allowing you to specify your entire data model as code.
 
 - **Import from Existing Sources**: Synth can import data from existing sources and automatically create data models. Synth currently has Alpha support for Postgres!
- 
+
 - **Data Inference**: While ingesting data, Synth automatically infers the relations, distributions and types of the dataset.
 
-- **Database Agnostic**: Synth supports semi-structured data and is database agnostic - playing nicely with SQL and NoSQL databases.  
- 
-- **Semantic Data Types**: Synth integrates with the (amazing) Python [Faker](https://pypi.org/project/Faker/) library, supporting generation of thousands of semantic types (e.g. credit card numbers, email addresses etc.) as well as locales.
+- **Database Agnostic**: Synth supports semi-structured data and is database agnostic - playing nicely with SQL and NoSQL databases.
+
+- **Semantic Data Types**: Synth has a library of semantic 'faker' types to cover PII like names, addresses, credit card numbers etc.

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -5,7 +5,7 @@ module.exports = {
     baseUrl: '/synth/',
     onBrokenLinks: 'warn',
     onBrokenMarkdownLinks: 'warn',
-    favicon: 'img/getsynth_favicon.png',
+    favicon: '/img/getsynth_favicon.png',
     organizationName: 'getsynth', // Usually your GitHub org/user name.
     projectName: 'synth', // Usually your repo name.
     plugins: [
@@ -36,7 +36,7 @@ module.exports = {
             title: 'Synth',
             logo: {
                 alt: 'Synth',
-                src: 'img/getsynth_identicon.png',
+                src: '/img/getsynth_identicon.png',
             },
             items: [
                 {

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {Redirect} from '@docusaurus/router';
 
 const Home = () => {
-    return <Redirect to="getting_started/synth"/>;
+    return <Redirect to="/synth/getting_started/synth"/>;
 };
 
 export default Home;


### PR DESCRIPTION
- Fixes typos
- Better explanations for `field reference` and other related items
- Also makes paths relative so docs won't break when we change `baseUrl`