### PR TITLE
Fix clippy and windows test workflows

### DIFF
--- a/.github/workflows/synth-test.yml
+++ b/.github/workflows/synth-test.yml
@@ -20,19 +20,17 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-05-17
-      - run: |
-          RUSTFLAGS="-D warnings" cargo +nightly-2021-05-17 test
+          toolchain: nightly
+          override: true
+      - run: cargo test
   clippy_test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, windows-latest ]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-05-17
+          toolchain: nightly
+          override: true
           components: clippy
-      - run: RUSTFLAGS="-D warnings" cargo clippy --tests --all-targets -- -D warnings
+      - run: cargo clippy --tests --all-targets -- -D warnings
 

--- a/synth/src/sampler.rs
+++ b/synth/src/sampler.rs
@@ -31,7 +31,7 @@ impl<'r> Sampler<'r> {
     ) -> Result<Value> {
         let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
 
-        let graph = Graph::from_namespace(&self.namespace)?;
+        let graph = Graph::from_namespace(self.namespace)?;
         let mut model = graph.into_iterator(&mut rng);
 
         let target = target as u64;
@@ -86,7 +86,7 @@ impl<'r> Sampler<'r> {
         progress_bar.finish();
 
         if let Some(name) = collection {
-            let just = output.remove(&name.to_string()).ok_or(failed!(
+            let just = output.remove(&name.to_string()).ok_or_else(|| failed!(
                 target: Release,
                 "generated namespace does not have a collection {}",
                 name


### PR DESCRIPTION
I believe this should fix the windows test and clippy workflows. There's no need to set "-D warnings" env when testing, as it is already applied when running cargo build. The clippy workflow should now select the nightly binary by default and no longer complain.