### PR TITLE
fix: Error out of malformed streams instead of panicking

### DIFF
--- a/gen/src/ser.rs
+++ b/gen/src/ser.rs
@@ -139,10 +139,13 @@ where
                     ser.serialize(serializer)
                 }
                 Special::Error(error) => Err(S::Error::custom(error)),
-                otherwise => todo!(
-                    "uh oh! Looks like we need to complete this pattern for {}!",
-                    otherwise
-                ),
+                otherwise => {
+                    let err = format!(
+                        "Stream of generated tokens is incomplete: the generated stream is malformed. Expected new data, instead got: {}",
+                        otherwise
+                    );
+                    Err(S::Error::custom(err))
+                }
             },
             Token::Primitive(primitive) => primitive.serialize(serializer),
         }


### PR DESCRIPTION
Fixes an issue arising when, at generation time, a generated value is of an incorrect type to be used as an argument to `format` and a an explicit panic occurs as a result of left-over `todo!`'s.