### PR TITLE
Fix workflows RUSTFLAGS env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,10 @@ on:
 
 name: Upload Release Asset
 
-jobs:
+env:
+  RUSTFLAGS: "-D warnings"
 
+jobs:
   build:
     name: build 
     runs-on: ${{ matrix.os }}
@@ -26,7 +28,7 @@ jobs:
         toolchain: nightly-2021-05-17
     - id: tag
       uses: dawidd6/action-get-tag@v1
-    - run: RUSTFLAGS="-D warnings" cargo +nightly-2021-05-17 build --release
+    - run: cargo +nightly-2021-05-17 build --release
     - working-directory: target/release
       run: tar -czf synth.tar.gz synth
     - uses: actions/upload-artifact@v2
@@ -44,7 +46,7 @@ jobs:
           toolchain: nightly-2021-05-17
       - id: tag
         uses: dawidd6/action-get-tag@v1
-      - run: RUSTFLAGS="-D warnings" cargo +nightly-2021-05-17 build --release
+      - run: cargo +nightly-2021-05-17 build --release
       - uses: actions/upload-artifact@v2
         with:
           name: synth-${{ steps.tag.outputs.tag }}-windows-x86_64

--- a/.github/workflows/synth-bench.yml
+++ b/.github/workflows/synth-bench.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   BENCHPATH: /home/runner/work/synth/synth/synth
+  RUSTFLAGS: "-D warnings"
 jobs:
   synth_bench:
     runs-on: ubuntu-latest
@@ -23,7 +24,7 @@ jobs:
     - name: run benchmark
       id: bench
       run: |
-        body=$(RUSTFLAGS="-D warnings" cargo +nightly bench --manifest-path /home/runner/work/synth/synth/synth/Cargo.toml)
+        body=$(cargo +nightly bench --manifest-path /home/runner/work/synth/synth/synth/Cargo.toml)
         body="${body//'%'/'%25'}"
         body="${body//$'\n'/'%0A'}"
         body="${body//$'\r'/'%0D'}" 

--- a/.github/workflows/synth-mongo.yml
+++ b/.github/workflows/synth-mongo.yml
@@ -10,6 +10,9 @@ on:
 
   workflow_dispatch:
 
+env:
+  RUSTFLAGS: "-D warnings"
+
 jobs:
   e2e_tests_mongo:
     runs-on: ubuntu-latest
@@ -20,7 +23,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2021-05-17
-      - run: RUSTFLAGS="-D warnings" cargo +nightly-2021-05-17 install --debug --path=synth
+      - run: cargo +nightly-2021-05-17 install --debug --path=synth
       - run: |
           echo "Running generate test"
           cd synth/testing_harness/mongodb/synth

--- a/.github/workflows/synth-mysql.yml
+++ b/.github/workflows/synth-mysql.yml
@@ -10,6 +10,9 @@ on:
 
   workflow_dispatch:
 
+env:
+  RUSTFLAGS: "-D warnings"
+
 jobs:
   e2e_tests_mysql:
     runs-on: ubuntu-latest
@@ -64,7 +67,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2021-05-17
-      - run: RUSTFLAGS="-D warnings" cargo +nightly-2021-05-17 install --debug --path=synth
+      - run: cargo +nightly-2021-05-17 install --debug --path=synth
       - run: |
           echo "Running generate test"
           cd synth/testing_harness/mysql

--- a/.github/workflows/synth-postgres.yml
+++ b/.github/workflows/synth-postgres.yml
@@ -10,6 +10,9 @@ on:
 
   workflow_dispatch:
 
+env:
+  RUSTFLAGS: "-D warnings"
+
 jobs:
   e2e_tests_postgres:
     runs-on: ubuntu-latest
@@ -35,7 +38,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2021-05-17
-      - run: RUSTFLAGS="-D warnings" cargo +nightly-2021-05-17 install --debug --path=synth
+      - run: cargo +nightly-2021-05-17 install --debug --path=synth
       - run: |
           echo "Running generate test"
           cd synth/testing_harness/postgres

--- a/.github/workflows/synth-test-examples.yml
+++ b/.github/workflows/synth-test-examples.yml
@@ -6,6 +6,9 @@ on:
       - master
   workflow_dispatch:
 
+env:
+  RUSTFLAGS: "-D warnings"
+
 jobs:
   test_examples:
     runs-on: ubuntu-latest
@@ -14,6 +17,6 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2021-05-17
-      - run: RUSTFLAGS="-D warnings" cargo +nightly-2021-05-17 install --debug --path=synth
+      - run: cargo +nightly-2021-05-17 install --debug --path=synth
       - run: |
           bash "${GITHUB_WORKSPACE}/.github/workflows/scripts/test_examples.sh" ${GITHUB_WORKSPACE}/examples

--- a/.github/workflows/synth.yml
+++ b/.github/workflows/synth.yml
@@ -5,8 +5,10 @@ on:
     branches:
       - master
 
-jobs:
+env:
+  RUSTFLAGS: "-D warnings"
 
+jobs:
   tests:
     name: synth tests
     runs-on: ubuntu-latest
@@ -15,4 +17,4 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2021-05-17
-      - run: RUSTFLAGS="-D warnings" cargo +nightly-2021-05-17 test
+      - run: cargo +nightly-2021-05-17 test


### PR DESCRIPTION
This moves the `RUSTFLAGS` out of the command line into the `env` section of the workflow.