### PR TITLE
feat: remove synth init

### DIFF
--- a/.github/workflows/scripts/test_examples.sh
+++ b/.github/workflows/scripts/test_examples.sh
@@ -3,17 +3,12 @@
 cd $1
 for d in */ ; do
     cd "$d"
-    if synth init; then
-        for ns in */ ; do
-            if synth generate $ns --size 10; then
-                echo "Generated $ns"
-            else
-                echo "Failed generating $ns"
-                exit 1
-            fi
-        done
-    else
-        echo "Failed to init $d"
-        exit 1
-    fi
+    for ns in */ ; do
+        if synth generate $ns --size 10; then
+            echo "Generated $ns"
+        else
+            echo "Failed generating $ns"
+            exit 1
+        fi
+    done
 done

--- a/.github/workflows/synth-mongo.yml
+++ b/.github/workflows/synth-mongo.yml
@@ -27,7 +27,6 @@ jobs:
       - run: |
           echo "Running generate test"
           cd synth/testing_harness/mongodb/synth
-          synth init
           synth generate hospital --size 100 --to mongodb://localhost:27017/hospital
           cd ..
           COLLECTIONS=(hospitals doctors patients)

--- a/.github/workflows/synth-mysql.yml
+++ b/.github/workflows/synth-mysql.yml
@@ -71,7 +71,6 @@ jobs:
       - run: |
           echo "Running generate test"
           cd synth/testing_harness/mysql
-          synth init || true
           synth generate hospital_master --to ${{ env.DB_SCHEME }}://${{ env.MYSQL_USER }}:${{ env.MYSQL_ROOT_PASSWORD }}@${{ env.MYSQL_HOST }}:${{ env.MYSQL_PORT }}/${{ env.MYSQL_DATABASE }} --size 30
           bash "${GITHUB_WORKSPACE}/.github/workflows/scripts/validate_mysql_gen_count.sh"
       ## Clear out and repopulate DB

--- a/.github/workflows/synth-postgres.yml
+++ b/.github/workflows/synth-postgres.yml
@@ -42,7 +42,6 @@ jobs:
       - run: |
           echo "Running generate test"
           cd synth/testing_harness/postgres
-          synth init || true
           synth generate --size 10 hospital_master > hospital_data_generated.json
           diff hospital_data_generated.json hospital_data_generated_master.json || exit 1
       - run: |

--- a/README.md
+++ b/README.md
@@ -58,13 +58,9 @@ For more installation options, check out the [docs](https://getsynth.com/docs/ge
 
 ### Building a data model from scratch
 
-To start generating data without having a source to import from, you need to first initialise a workspace using `synth init [opt path]` (if no optional path is specified, the current directory will be used):
+To start generating data without having a source to import from, you need to add Synth schema files to a namespace directory:
 
-```bash
-$ synth init /some/path
-```
-
-Inside the workspace we'll create a namespace for our data model and call it `my_app`:
+To get started we'll create a namespace directory for our data model and call it `my_app`:
 
 ```bash
 $ mkdir my_app
@@ -129,13 +125,7 @@ $ synth generate my_app/ --size 2 | jq
 
 If you have an existing database, Synth can automatically generate a data model by inspecting the database.
 
-To get started, initialise your Synth workspace locally:
-
-```bash
-$ mkdir synth_workspace && cd synth_workspace && synth init
-```
-
-Then use the `synth import` command to build a data model from your Postgres or MongoDB database:
+You can use the `synth import` command to automatically generate Synth schema files from your Postgres, MySQL or MongoDB database:
 
 ```bash
 $ synth import tpch --from postgres://user:pass@localhost:5432/tpch

--- a/docs/docs/getting_started/cli.md
+++ b/docs/docs/getting_started/cli.md
@@ -9,32 +9,18 @@ title: Command-line
 
 ---
 
-### Command: init
-
-Usage: `synth init`
-
-This is the first command that should be run for any new or existing when starting out with Synth. 
-This initialises the workspace and  sets up all the local data necessary to run Synth.
-A `.synth/` subdirectory is created that is typically not committed to version control.
-
-This command is always safe to run multiple times though subsequent runs
-may give errors. This command will never erase your workspace.
-
----
-
 ### Command: import
 
 Usage: `synth import [OPTIONS] <namespace>`
 
-Synth can create namespaces from different data sources using the `synth import` command.
-Accidentally running `synth import` on an existing namespace is safe - the operation will fail.
+Synth can create schema files from different data sources using the `synth import` command.
+Accidentally running `synth import` on an existing directory is safe - the operation will fail.
 
-If a subdirectory for a given namespace does not exist in your workspace, Synth will create it.
+If a subdirectory for a given namespace does not exist, Synth will create it.
 
 #### Argument
 
-- `<namespace>` - The desired path to the imported namespace directory. Can only
-  be a path relative to the current (initialised) workspace root.
+- `<namespace>` - The path to the namespace directory into which to save schema files. The directory will be created by `synth`.
   
 #### Options
  
@@ -54,14 +40,13 @@ If a subdirectory for a given namespace does not exist in your workspace, Synth 
 
 Usage: `synth generate [OPTIONS] <namespace>`
 
-The `synth generate` command will generate data for a given namespace. This will not mutate anything in the underlying configuration.
+The `synth generate` command will generate data from a collection of schema files.
 
 If there is a misconfiguration in your schema (for example referring to a field that does not exist), `synth generate` will exit with a non-zero exit code and output an error message to help you understand which part of the schema is misconfigured.
 
 #### Argument
 
-- `<namespace>` - The path to the namespace you wish to generate data for. Can
-  only be a path relative to the current (initialised) workspace root.
+- `<namespace>` - The path to the namespace directory from which to load schema files.
   
 #### Options
 

--- a/docs/docs/getting_started/core-concepts.md
+++ b/docs/docs/getting_started/core-concepts.md
@@ -4,25 +4,6 @@ title: Core concepts
 
 This section covers the core concepts found in Synth.
 
-## Workspaces
-
-Workspaces are marked by the existence of a `.synth/` subdirectory. A workspace
-represents a set of synthetic data namespaces managed by Synth.
-
-A workspace can have *zero or more namespaces*. Each namespace is represented as
-a subdirectory of the workspace. All information pertaining to a workspace is in
-its directory, there is no external configuration.
-
-Below is an example directory structure for a workspace with a single
-namespace, `my_namepace`.
-
-```
-├── .synth
-└── my_namespace
-    ├── my_collection_1.json
-    └── my_collection_2.json
-``` 
-
 ## Namespaces
 
 The **namespace** is the top-level abstraction in Synth. Namespaces are the
@@ -30,22 +11,19 @@ equivalent of traditional [schemas][sql-schemas] in the world of relational
 databases likes PostgreSQL. [References](#field-references) can exist between
 fields in a given namespace, but never across namespaces.
 
-Namespaces are represented as sub-directories in a workspace. For example, a
-workspace with single namespace `some_namespace` would have the following
+Namespaces are simply directories from which `synth` reads a collection of
+schema files. For example, a namespace `blog` could have the following
 structure:
 
 ```
-├── .synth
-└── my_namespace
+└── blog/
+    ├── users.json
+    └── posts.json 
 ``` 
 
-You can have as many namespaces as you like within a workspace:
-
-```
-├── .synth
-├── some_namespace
-└── some_other_namespace 
-```
+Any file whose extension is `.json` in a namespace directory will be opened by
+the [`synth generate`][synth-generate] subcommand and considered part of the
+namespace's schema.
 
 ## Collections
 
@@ -54,26 +32,20 @@ their name and correspond to [tables][sql-tables] in the world of relational
 databases. Strictly speaking, collections are a super-set of tables as they are
 in fact arbitrarily deep JSON document trees.
 
-Collections are represented in a workspace as JSON files. The *name* of a
-collection (the way it is referred to by [`synth`][synth]) is its filename
+Collections are represented in a namespace directory as JSON files. The *name*
+of a collection (the way it is referred to by [`synth`][synth]) is its filename
 without the extension. For example the file `bank/transactions.json` defines a
 collection named `transactions` in a namespace `bank`.
 
 For a more comprehensive example, let's imagine our namespace `bank` has a
-collection `transactions` and another collection `users`. The workspace
+collection `transactions` and another collection `users`. The directory
 structure then looks like this:
 
 ```
-├── .synth
-└── bank
+└── bank/
     ├── transactions.json
     └── users.json 
 ```
-
-Collections inside a given namespace need to have unique names. You can however
-have the same collection name in different namespaces. For
-example `bank/transactions.json` and `forex/transactions.json` is a valid
-workspace.
 
 Collections must be valid instances of the [`synth` schema][schema] that
 describe an array. This means at the top-level all collections must

--- a/docs/docs/getting_started/hello-world.md
+++ b/docs/docs/getting_started/hello-world.md
@@ -2,37 +2,23 @@
 title: Hello world
 ---
 
-After installing [`synth`][synth], the next step is to create a **workspace**. 
+After installing [`synth`][synth], the next step is to create a **namespace**. 
 
-Workspaces are directories in your filesystem that [`synth`][synth] uses to read your schemas from. Currently [`synth`][synth] reads schemas written in a specialized JSON data model. You can find out everything there is to know about [`synth`][synth] schemas in the [Generators][generators] section or in the [Schema][schema] section. In this section we will show you how to set up a simple "hello world" data generator.
+Namespaces are directories in your filesystem that [`synth`][synth] uses to read your schemas from. Currently [`synth`][synth] reads schemas written in a specialized JSON data model. You can find out everything there is to know about [`synth`][synth] schemas in the [Generators][generators] section or in the [Schema][schema] section. In this section we will show you how to set up a simple "hello world" data generator.
 
-To create and initialise a workspace called `synth_workspace` in your current working directory, run:
-
-```bash
-mkdir synth_workspace && cd synth_workspace && synth init
-```
-
-:::note Note
-
-The command [`synth init`][synth-init] creates a marker directory called `.synth` in the directory where it is run. This marker directory acts as simply an anchor to tell [`synth`][synth] that this is a workspace.
-:::
-
-Next we need to create a **namespace**. Namespaces are directories in an
-initialized [`synth`][synth] workspace. All the schema files in a given
-namespace are collated and compiled together at runtime.
-
-Let's create a namespace called `my_namespace`:
+To create a namespace, just create a new directory:
 
 ```bash
-mkdir my_namespace
+mkdir hello_synth
 ```
 
 Finally, we need to add a **collection** to our namespace. Collections describe
 the "shape" of the data we want to generate. They are individual JSON files
-within a namespace written according to the [`synth` schema][generators].
+within a namespace directory written according to
+the [`synth` schema][generators].
 
-To create a collection called "dummy" in our namespace, simply copy/paste the content of the following example in a file
-at `synth_workspace/my_namespace/dummy.json`:
+To create a collection called "say_hello" in our namespace, simply copy/paste the content of the following example in a file
+at `hello_synth/say_hello.json`:
 
 ```json synth
 {
@@ -56,9 +42,11 @@ button that lets you preview how [`synth`][synth] would output the corresponding
 data.
 
 Finally, run
+
 ```bash
-synth generate my_namespace/
+synth generate hello_synth/
 ```
+
 and you should see an output very close to the output of the snippet.
 
 ## Where to go from here

--- a/synth/benches/bench.rs
+++ b/synth/benches/bench.rs
@@ -3,18 +3,6 @@
 
 use synth::cli::{Args, Cli};
 
-fn bench_init() {
-    async_std::task::block_on(
-        #[allow(unused_must_use)]
-        async {
-            Cli::new(Args::Init { init_path: None })
-                .unwrap()
-                .run()
-                .await;
-        },
-    )
-}
-
 fn bench_generate_1_to_stdout() {
     bench_generate_n_to_stdout(1);
 }
@@ -43,7 +31,6 @@ fn bench_generate_n_to_stdout(size: usize) {
 }
 
 iai::main!(
-    bench_init,
     bench_generate_1_to_stdout,
     bench_generate_100_to_stdout,
     bench_generate_10000_to_stdout,


### PR DESCRIPTION
This removes `synth init` and references to it in documentation, in CI and README.

Closes #83.