### PR TITLE
fix: catalog is now inferred automatically for relational databases.

### DIFF
--- a/synth/src/datasource/mysql_datasource.rs
+++ b/synth/src/datasource/mysql_datasource.rs
@@ -24,8 +24,7 @@ use synth_core::Content;
 ///   Ideally, the user can define a way to force certain fields as bool rather than i8.
 
 pub struct MySqlDataSource {
-    pool: Pool<MySql>,
-    connect_params: String,
+    pool: Pool<MySql>
 }
 
 #[async_trait]
@@ -40,8 +39,7 @@ impl DataSource for MySqlDataSource {
                 .await?;
 
             Ok::<Self, anyhow::Error>(MySqlDataSource {
-                pool,
-                connect_params: connect_params.to_string(),
+                pool
             })
         })
     }
@@ -71,19 +69,11 @@ impl RelationalDataSource for MySqlDataSource {
         Ok(result)
     }
 
-    fn get_catalog(&self) -> Result<&str> {
-        self.connect_params
-            .split('/')
-            .last()
-            .ok_or_else(|| anyhow!("No catalog specified in the uri"))
-    }
-
     async fn get_table_names(&self) -> Result<Vec<String>> {
         let query = r"SELECT table_name FROM information_schema.tables
-            WHERE table_schema = ? and table_type = 'BASE TABLE'";
+            WHERE table_schema = DATABASE() and table_type = 'BASE TABLE'";
 
         let table_names: Vec<String> = sqlx::query(query)
-            .bind(self.get_catalog()?)
             .fetch_all(&self.pool)
             .await?
             .iter()
@@ -97,11 +87,10 @@ impl RelationalDataSource for MySqlDataSource {
         let query = r"SELECT column_name, ordinal_position, is_nullable, data_type,
             character_maximum_length
             FROM information_schema.columns
-            WHERE table_name = ? AND table_schema = ?";
+            WHERE table_name = ? AND table_schema = DATABASE()";
 
         let column_infos = sqlx::query(query)
             .bind(table_name)
-            .bind(self.get_catalog()?)
             .fetch_all(&self.pool)
             .await?
             .into_iter()
@@ -114,10 +103,9 @@ impl RelationalDataSource for MySqlDataSource {
     async fn get_primary_keys(&self, table_name: &str) -> Result<Vec<PrimaryKey>> {
         let query: &str = r"SELECT column_name, data_type
             FROM information_schema.columns
-            WHERE table_schema = ? AND table_name = ? AND column_key = 'PRI'";
+            WHERE table_schema = DATABASE() AND table_name = ? AND column_key = 'PRI'";
 
         sqlx::query(query)
-            .bind(self.get_catalog()?)
             .bind(table_name)
             .fetch_all(&self.pool)
             .await?
@@ -129,10 +117,9 @@ impl RelationalDataSource for MySqlDataSource {
     async fn get_foreign_keys(&self) -> Result<Vec<ForeignKey>> {
         let query: &str = r"SELECT table_name, column_name, referenced_table_name, referenced_column_name
             FROM information_schema.key_column_usage
-            WHERE referenced_table_schema = ?";
+            WHERE referenced_table_schema = DATABASE()";
 
         sqlx::query(query)
-            .bind(self.get_catalog()?)
             .fetch_all(&self.pool)
             .await?
             .into_iter()

--- a/synth/src/datasource/postgres_datasource.rs
+++ b/synth/src/datasource/postgres_datasource.rs
@@ -20,8 +20,7 @@ use synth_core::Content;
 
 pub struct PostgresDataSource {
     pool: Pool<Postgres>,
-    single_thread_pool: Pool<Postgres>,
-    connect_params: String,
+    single_thread_pool: Pool<Postgres>
 }
 
 #[async_trait]
@@ -43,8 +42,7 @@ impl DataSource for PostgresDataSource {
 
             Ok::<Self, anyhow::Error>(PostgresDataSource {
                 pool,
-                single_thread_pool,
-                connect_params: connect_params.to_string(),
+                single_thread_pool
             })
         })
     }
@@ -70,20 +68,12 @@ impl RelationalDataSource for PostgresDataSource {
         Ok(result)
     }
 
-    fn get_catalog(&self) -> Result<&str> {
-        self.connect_params
-            .split('/')
-            .last()
-            .ok_or_else(|| anyhow!("No catalog specified in the uri"))
-    }
-
     async fn get_table_names(&self) -> Result<Vec<String>> {
         let query = r"SELECT table_name
         FROM information_schema.tables
-        WHERE table_catalog = $1 AND table_schema = 'public' AND table_type = 'BASE TABLE'";
+        WHERE table_catalog = current_catalog AND table_schema = 'public' AND table_type = 'BASE TABLE'";
 
         sqlx::query(query)
-            .bind(self.get_catalog()?)
             .fetch_all(&self.pool)
             .await?
             .iter()
@@ -98,11 +88,10 @@ impl RelationalDataSource for PostgresDataSource {
         let query = r"SELECT column_name, ordinal_position, is_nullable, udt_name,
         character_maximum_length
         FROM information_schema.columns
-        WHERE table_name = $1 AND table_catalog = $2";
+        WHERE table_name = $1 AND table_catalog = current_catalog";
 
         sqlx::query(query)
             .bind(table_name)
-            .bind(self.get_catalog()?)
             .fetch_all(&self.pool)
             .await?
             .into_iter()

--- a/synth/src/datasource/relational_datasource.rs
+++ b/synth/src/datasource/relational_datasource.rs
@@ -120,8 +120,6 @@ pub trait RelationalDataSource: DataSource {
         query_params: Vec<&str>,
     ) -> Result<Self::QueryResult>;
 
-    fn get_catalog(&self) -> Result<&str>;
-
     async fn get_table_names(&self) -> Result<Vec<String>>;
 
     async fn get_columns_infos(&self, table_name: &str) -> Result<Vec<ColumnInfo>>;


### PR DESCRIPTION
This PR removes the custom parsing of the catalog name for relational databases which used naive string manipulation.

We now instead use built-in database functions like `current_catalog` and `DATABASE()` for PostgreSQL and MySQL respectively.

I've left the fix for MongoDB out of it, as the [official](https://docs.mongodb.com/manual/reference/connection-string/) mongodb connection string does not support specifying the database in the URI. This is going to require the addition of a `--db` flag which is only relevant for the mongodb case:

```
synth import --from mobgodb://localhost:27107 --db my_database my_namespace && synth generate --to mongodb://localhost:27017 --db my_database my_namespace
```

However the current architecture which parses URI strings to build the `Import/ExportStrategy`s won't work out of the box so this is going to require a larger diff and some refactoring.