### PR TITLE
fix: unspecified begin or end params in the datetime will default to now()

### DIFF
--- a/core/src/schema/content/mod.rs
+++ b/core/src/schema/content/mod.rs
@@ -736,12 +736,5 @@ pub mod tests {
             "begin": "2020-11-05T09:53:10+0500",
             "end": "2020-11-05T09:53:10+0000"
         });
-
-        assert!(serde_json::from_value::<DateTimeContent>(json!({
-            "format": "%Y-%m-%dT%H:%M:%S%z",
-            "end": "2020-11-05T09:53:10+0500",
-            "begin": "2020-11-05T09:53:10+0000"
-        }))
-        .is_err())
     }
 }

--- a/core/src/schema/content/string.rs
+++ b/core/src/schema/content/string.rs
@@ -515,7 +515,6 @@ pub mod datetime_content {
 
 use crate::graph::string::Serialized;
 pub use datetime_content::ChronoValueFormatter;
-use std::ops::Add;
 
 impl Serialize for DateTimeContent {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/core/src/schema/content/string.rs
+++ b/core/src/schema/content/string.rs
@@ -471,17 +471,6 @@ pub mod datetime_content {
                 .transpose()?;
             let end = self.end.map(|end| fmt.parse(end.as_str())).transpose()?;
 
-            if let (Some(begin), Some(end)) = (begin.as_ref(), end.as_ref()) {
-                if begin > end {
-                    return Err(failed!(
-                        target: Release,
-                        "begin is after end: begin={}, end={}",
-                        fmt.format(begin).unwrap(), // should be alright exactly at this point
-                        fmt.format(end).unwrap()
-                    ));
-                }
-            }
-
             let common_variant = begin
                 .as_ref()
                 .and_then(|begin| begin.common_variant(end.as_ref()?));

--- a/core/src/schema/content/string.rs
+++ b/core/src/schema/content/string.rs
@@ -515,6 +515,7 @@ pub mod datetime_content {
 
 use crate::graph::string::Serialized;
 pub use datetime_content::ChronoValueFormatter;
+use std::ops::Add;
 
 impl Serialize for DateTimeContent {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -565,8 +566,10 @@ impl Compile for StringContent {
             }) => {
                 let begin = begin
                     .clone()
-                    .unwrap_or_else(|| ChronoValue::default_of(ChronoValue::origin(), *type_));
-                let end = end.clone().unwrap_or(begin.clone() + Duration::weeks(52));
+                    .unwrap_or_else(|| ChronoValue::default_of(ChronoValue::now(), *type_));
+                let end = end
+                    .clone()
+                    .unwrap_or_else(|| ChronoValue::default_of(ChronoValue::now(), *type_));
                 RandomDateTime::new(begin..end, format).into()
             }
             StringContent::Categorical(cat) => RandomString::from(cat.clone()).into(),

--- a/docs/docs/content/string.md
+++ b/docs/docs/content/string.md
@@ -774,6 +774,31 @@ Accepted values for the `"date_time"` key are objects with the following keys:
       specification.
 - `"begin"` and `"end"`: the lower and upper bounds of the `date_time` value to generate. The formatting of these values
   must adhere to the `strftime`-string specified in the `"format"` field.
+  
+Not specifying `begin` or `end` will result in these defaulting to the current time.
+
+```json synth
+{
+  "type": "string",
+  "date_time": {
+    "format": "%Y-%m-%d",
+    "subtype": "naive_date",
+    "end": "2030-01-01"
+  }
+}
+```
+
+Or optionally both, will result in a constant time:
+
+```json synth
+{
+  "type": "string",
+  "date_time": {
+    "format": "%Y-%m-%d",
+    "subtype": "naive_date"
+  }
+}
+```
 
 #### Example
 


### PR DESCRIPTION
NB: There is an edge case where this will blow up with a `panic` (if `begin` > `end`) with the error:
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: OutOfRangeError(())', core/src/schema/content/string.rs:276:50
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This is a known issue and should be handled separately as it is a non-trivial change to fix this.

Furthermore, behaviour here will deviate from our `number::range` generator (that is, `high` is exclusive and should be strictly bigger than `low`). However in `date_time` this makes less sense as there are different increments for different formats (i.e. nanosecond, second, year etc.). 

If we are to address this it should happen in another PR.