### PR TITLE
feat: feature-gate telemetry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         toolchain: nightly
     - id: tag
       uses: dawidd6/action-get-tag@v1
-    - run: cargo +nightly build --release
+    - run: cargo +nightly build --release --features telemetry
     - working-directory: target/release
       run: tar -czf synth.tar.gz synth
     - uses: actions/upload-artifact@v2
@@ -46,7 +46,7 @@ jobs:
           toolchain: nightly
       - id: tag
         uses: dawidd6/action-get-tag@v1
-      - run: cargo +nightly build --release
+      - run: cargo +nightly build --release --features telemetry
       - uses: actions/upload-artifact@v2
         with:
           name: synth-${{ steps.tag.outputs.tag }}-windows-x86_64

--- a/synth/Cargo.toml
+++ b/synth/Cargo.toml
@@ -13,6 +13,10 @@ license = "Apache-2.0"
 name = "bench"
 harness = false
 
+[features]
+default = []
+telemetry = ["posthog-rs", "uuid"]
+
 [build-dependencies]
 git2 = "0.13.20"
 
@@ -25,7 +29,10 @@ iai = "0.1"
 lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive"]}
 serde_json = "1.0"
-posthog-rs = "0.1.3"
+
+# Telemetry related dependencies
+uuid = { version = "0.8.2", features = ["v4"], optional = true }
+posthog-rs = { version = "0.1.3", optional = true }
 
 colored = "2.0.0"
 anyhow = "1.0.32"
@@ -57,7 +64,6 @@ rust_decimal = "1.10.3"
 indicatif = "0.15.0"
 
 dirs = "3.0.2"
-uuid = { version = "0.8.2", features = ["v4"] }
 mongodb = {version = "2.0.0-beta.3", features = ["sync", "bson-chrono-0_4"] , default-features = false}
 
 sqlx = { version = "0.5.7", features = [ "postgres", "mysql", "runtime-async-std-native-tls", "decimal", "chrono" ] }

--- a/synth/benches/bench.rs
+++ b/synth/benches/bench.rs
@@ -26,7 +26,7 @@ fn bench_generate_n_to_stdout(size: usize) {
             seed: Some(0),
             random: false,
         };
-        Cli::new(args).unwrap().run().await.unwrap()
+        Cli::new().unwrap().run(args).await.unwrap()
     });
 }
 

--- a/synth/src/main.rs
+++ b/synth/src/main.rs
@@ -1,9 +1,16 @@
 use anyhow::Result;
 use structopt::StructOpt;
 
-use synth::cli::{Args, Cli};
-
 #[async_std::main]
 async fn main() -> Result<()> {
-    Cli::new(Args::from_args())?.run().await
+    let args = synth::cli::Args::from_args();
+    let cli = synth::cli::Cli::new()?;
+
+    #[cfg(feature = "telemetry")]
+    synth::cli::telemetry::with_telemetry(args, |args| cli.run(args)).await?;
+
+    #[cfg(not(feature = "telemetry"))]
+    cli.run(args).await?;
+
+    Ok(())
 }


### PR DESCRIPTION
This
- refactors the telemetry entrypoint to be more general
- puts the posthog telemetry code under the feature gate `telemetry`, which is disabled by default.
- add the `telemetry` feature flag to GH CI/CD release builds

In particular, users and contributors building from source on `master` will not unnecessarily spam the posthog event stream with WIP issues (i.e. `cargo run`).