### PR TITLE
fix: vercel action uses workdir

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,9 +11,6 @@ on:
 jobs:
   deploy-vercel:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: docs
     steps:
       - uses: actions/checkout@v2
       - uses: amondnet/vercel-action@v20
@@ -22,6 +19,7 @@ jobs:
           vercel-args: --prod
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: ./docs
 
   deploy-pages:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
I believe the vercel action has two issues:

- It cannot fetch the deployment (even though it actually goes through), which could be permission related
- The deployment is incorrect because the working-directory was not set to ./docs

This fixes the latter. We'll see about the former.