### PR TITLE
fix: vercel action uses scope

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,7 @@ jobs:
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           working-directory: ./docs
+          scope: ${{ secrets.VERCEL_ORG_ID }}
 
   deploy-pages:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
As mentioned in #138, action does not find deployment on `inspect`.

Looking at the [source](https://github.com/amondnet/vercel-action/blob/58bc126a0052bb8387f8e0b3d72e77562ac7a72f/index.js#L161), it seems like it needs the explicit run variable `scope` to find the deployment for a team target.