### PR TITLE
fix: rewrite truncate node

### DIFF
--- a/core/src/graph/array.rs
+++ b/core/src/graph/array.rs
@@ -29,7 +29,7 @@ impl Generator for RandomArray {
 }
 
 type ArrayNodeInner =
-    AndThenTry<OwnedDevaluize<Box<Graph>, u64>, Box<dyn Fn(u64) -> RandomArray>, RandomArray>;
+    AndThenTry<SizeGenerator, Box<dyn Fn(u64) -> RandomArray>, RandomArray>;
 
 derive_generator! {
     yield Token,
@@ -38,10 +38,7 @@ derive_generator! {
 }
 
 impl ArrayNode {
-    pub fn new_with(len: Graph, content: Graph) -> Self {
-        let len: OwnedDevaluize<Box<Graph>, u64> = Box::new(len)
-            .map_complete(number_from_ok::<u64> as fn(Result<Value, Error>) -> Result<u64, Error>)
-            .exhaust();
+    pub fn new_with(len: SizeGenerator, content: Graph) -> Self {
         let content = Rc::new(RefCell::new(content));
         let closure: Box<dyn Fn(u64) -> RandomArray> =
             Box::new(move |length| RandomArray::with_length(length, content.clone()));

--- a/core/src/graph/prelude.rs
+++ b/core/src/graph/prelude.rs
@@ -22,5 +22,5 @@ pub use anyhow::Error as AnyhowError;
 
 pub use super::{
     number_from_ok, value_from_ok, value_from_ok_number, Devaluize, Graph, JustToken,
-    OnceInfallible, OwnedDevaluize, TokenOnce, Value, Valuize,
+    OnceInfallible, OwnedDevaluize, TokenOnce, Value, Valuize, StringGenerator, SizeGenerator
 };

--- a/core/src/schema/content/array.rs
+++ b/core/src/schema/content/array.rs
@@ -25,7 +25,8 @@ impl ArrayContent {
 
 impl Compile for ArrayContent {
     fn compile<'a, C: Compiler<'a>>(&'a self, mut compiler: C) -> Result<Graph> {
-        let length = compiler.build("length", self.length.as_ref())?;
+        let length = compiler.build("length", self.length.as_ref())?
+            .into_size();
         let content = compiler.build("content", &self.content)?;
         Ok(Graph::Array(ArrayNode::new_with(length, content)))
     }

--- a/core/src/schema/content/string.rs
+++ b/core/src/schema/content/string.rs
@@ -182,7 +182,7 @@ pub enum SerializedContent {
 #[serde(rename_all = "lowercase")]
 pub struct TruncatedContent {
     content: Box<Content>,
-    length: usize,
+    length: Box<Content>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -575,9 +575,12 @@ impl Compile for StringContent {
                     RandomString::from(Serialized::new_json(inner)).into()
                 }
             },
-            StringContent::Truncated(trunc) => {
-                let inner = trunc.content.compile(compiler)?;
-                RandomString::from(Truncated::new(trunc.length, inner)?).into()
+            StringContent::Truncated(TruncatedContent { box length, box content }) => {
+                let content = compiler.build("content", content)?
+                    .into_string();
+                let length = compiler.build("length", length)?
+                    .into_size();
+                RandomString::from(Truncated::new(content, length)).into()
             }
             StringContent::Uuid(_uuid) => RandomString::from(UuidGen {}).into(),
         };

--- a/dist/playground/src/app.rs
+++ b/dist/playground/src/app.rs
@@ -32,7 +32,7 @@ impl State {
         // Build the generator graph
         let mut graph = NamespaceCompiler::new_flat(&body).compile()?;
         if let Some(size) = size {
-            let size = Graph::Number(RandomU64::constant(size).into());
+            let size = Graph::Number(RandomU64::constant(size).into()).into_size();
             graph = Graph::Array(ArrayNode::new_with(size, graph));
         }
 

--- a/docs/docs/content/string.md
+++ b/docs/docs/content/string.md
@@ -851,7 +851,7 @@ The `truncated` generator truncates the output of it's inner generator to a fixe
 If the output of its inner generator is less than or equal to the length, it is left untouched. 
 
 `truncated` has 2 fields,
-- `length`: The number of characters to truncate to.
+- `length`: The number of characters to truncate to. This can be any Synth generator that yields a non-negative Number.
 - `content`: The content to be truncated. This can be any Synth generator that yields a String.
 
 #### Example


### PR DESCRIPTION
The old `truncate` node was breaking a lot of the internal generators API semantics and as a result was implemented in such a way that we couldn't truncate through a reference nor specify the length of the output dynamically.

This re-implements `truncate` to fix those issues.