### PR TITLE
Fix instances where 'synth --version' is used to be 'synth version'.

### DIFF
--- a/docs/blog/2021-08-31-seeding-databases-tutorial.md
+++ b/docs/blog/2021-08-31-seeding-databases-tutorial.md
@@ -324,7 +324,7 @@ pages of the official documentation.
 Once the installer script is done, try running
 
 ```bash
-$ synth --version
+$ synth version
 synth 0.5.4
 ```
 

--- a/docs/docs/getting_started/installation.md
+++ b/docs/docs/getting_started/installation.md
@@ -34,7 +34,7 @@ Finally [add `synth` to your PATH](https://www.architectryan.com/2018/03/17/add-
 You should now be able to use `synth`:
 
 ```
-PS C:\Users\user\workspace> synth --version
+PS C:\Users\user\workspace> synth version
 ```
 
 </TabItem>


### PR DESCRIPTION
When going through your docs I noticed that the installation instructions for windows were slightly incorrect. It seems that `synth --version` is the incorrect command, and `synth version` is the correct command. I also updated another instance where it was used in a blog post recently.