### PR TITLE
feat: postgres specify search path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "synth"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "anyhow",
  "async-std",
@@ -3148,7 +3148,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "bimap",

--- a/docs/docs/integrations/postgres.md
+++ b/docs/docs/integrations/postgres.md
@@ -1,3 +1,4 @@
+
 ---
 title: PostgreSQL
 ---
@@ -11,14 +12,14 @@ The Synth PostgreSQL integration is currently **in beta**.
 ## Usage
 
 `synth` can use [PostgreSQL](https://www.postgresql.org/) as a data source or
-sink. Connecting `synth` to a PostgreSQL is as simple as specifying a URI during
-the `import` or `generate`
+sink. Connecting `synth` to a PostgreSQL is as simple as specifying a URI 
+and schema during the `import` or `generate`
 phase.
 
 ### URI format
 
 ```bash
-postgres://<username>:<password>@<host>:<port>/<schema>
+postgres://<username>:<password>@<host>:<port>/<catalog>
 ```
 
 ## Import
@@ -30,7 +31,8 @@ will be created from your database schema, and
 a [collection](../getting_started/core-concepts#collections) is created for each
 table in a separate JSON file. `synth` will map database columns to fields in
 the collections it creates. It then provides default generators for every
-collection.
+collection. Synth will default to the `public` schema but this can be 
+overriden with the `--schema` flag.
 
 `synth` will automatically detect primary key and foreign key constraints at
 import time and update the namespace and collection to reflect them. **Primary
@@ -145,7 +147,8 @@ And the corresponding `synth` collection:
 ### Example Import Command
 
 ```bash
-synth import --from postgres://user:pass@localhost:5432/postgres my_namespace 
+synth import --from postgres://user:pass@localhost:5432/postgres --schema 
+main my_namespace 
 ```
 
 ### Example
@@ -163,5 +166,6 @@ data and inserting it in the right order such that no constraints are violated.
 ### Example Generation Command
 
 ```bash
-synth generate --to postgres://user:pass@localhost:5432/ my_namespace
+synth generate --to postgres://user:pass@localhost:5432/ --schema 
+main my_namespace
 ```

--- a/synth/benches/bench.rs
+++ b/synth/benches/bench.rs
@@ -25,6 +25,7 @@ fn bench_generate_n_to_stdout(size: usize) {
             to: None,
             seed: Some(0),
             random: false,
+            schema: None
         };
         Cli::new().unwrap().run(args).await.unwrap()
     });

--- a/synth/src/cli/db_utils.rs
+++ b/synth/src/cli/db_utils.rs
@@ -1,0 +1,4 @@
+pub struct DataSourceParams {
+    pub uri: Option<String>, //perhaps uri is not a good name here as this could be a file path
+    pub schema: Option<String>
+}

--- a/synth/src/cli/import.rs
+++ b/synth/src/cli/import.rs
@@ -17,12 +17,12 @@ use crate::cli::stdf::{FileImportStrategy, StdinImportStrategy};
 
 pub trait ImportStrategy {
     fn import(&self) -> Result<Namespace> {
-        ns_from_value(self.into_value()?)
+        ns_from_value(self.as_value()?)
     }
     fn import_collection(&self, _name: &Name) -> Result<Content> {
-        collection_from_value(&self.into_value()?)
+        collection_from_value(&self.as_value()?)
     }
-    fn into_value(&self) -> Result<Value>;
+    fn as_value(&self) -> Result<Value>;
 }
 
 impl TryFrom<DataSourceParams> for Box<dyn ImportStrategy> {

--- a/synth/src/cli/import_utils.rs
+++ b/synth/src/cli/import_utils.rs
@@ -31,6 +31,8 @@ pub(crate) fn build_namespace_import<T: DataSource + RelationalDataSource>(
 
     let mut namespace = Namespace::default();
 
+    task::block_on(datasource.set_schema())?;
+
     info!("Building namespace collections...");
     populate_namespace_collections(&mut namespace, &table_names, datasource)?;
 

--- a/synth/src/cli/import_utils.rs
+++ b/synth/src/cli/import_utils.rs
@@ -26,12 +26,13 @@ struct FieldContentWrapper(Content);
 pub(crate) fn build_namespace_import<T: DataSource + RelationalDataSource>(
     datasource: &T,
 ) -> Result<Namespace> {
+
+    task::block_on(datasource.set_schema())?;
+
     let table_names = task::block_on(datasource.get_table_names())
         .with_context(|| "Failed to get table names".to_string())?;
 
     let mut namespace = Namespace::default();
-
-    task::block_on(datasource.set_schema())?;
 
     info!("Building namespace collections...");
     populate_namespace_collections(&mut namespace, &table_names, datasource)?;

--- a/synth/src/cli/import_utils.rs
+++ b/synth/src/cli/import_utils.rs
@@ -27,8 +27,6 @@ pub(crate) fn build_namespace_import<T: DataSource + RelationalDataSource>(
     datasource: &T,
 ) -> Result<Namespace> {
 
-    task::block_on(datasource.set_schema())?;
-
     let table_names = task::block_on(datasource.get_table_names())
         .with_context(|| "Failed to get table names".to_string())?;
 

--- a/synth/src/cli/mod.rs
+++ b/synth/src/cli/mod.rs
@@ -1,17 +1,3 @@
-use std::convert::TryInto;
-use std::path::PathBuf;
-
-use anyhow::{Context, Result};
-use rand::RngCore;
-use structopt::StructOpt;
-
-use db_utils::DataSourceParams;
-use synth_core::{graph::json, Name};
-
-use crate::cli::export::{ExportParams, ExportStrategy};
-use crate::cli::import::ImportStrategy;
-use crate::cli::store::Store;
-
 mod export;
 mod import;
 mod import_utils;
@@ -21,20 +7,17 @@ mod postgres;
 mod stdf;
 mod store;
 
-use crate::cli::export::SomeExportStrategy;
 use crate::cli::export::{ExportParams, ExportStrategy};
-use crate::cli::import::{ImportStrategy, ImportParams};
+use crate::cli::import::ImportStrategy;
 use crate::cli::store::Store;
+use crate::cli::db_utils::DataSourceParams;
 use crate::version::print_version_message;
 
 use anyhow::{Context, Result};
-
 use std::path::PathBuf;
 use structopt::StructOpt;
 use structopt::clap::AppSettings;
-
 use rand::RngCore;
-
 use synth_core::{Name, graph::json};
 use std::process::exit;
 use std::convert::TryInto;
@@ -42,6 +25,7 @@ use std::convert::TryInto;
 #[cfg(feature = "telemetry")]
 pub mod telemetry;
 pub(crate) mod config;
+mod db_utils;
 
 pub struct Cli {
     store: Store

--- a/synth/src/cli/mongo.rs
+++ b/synth/src/cli/mongo.rs
@@ -155,7 +155,7 @@ fn bson_to_content(bson: &Bson) -> Content {
 }
 
 impl ExportStrategy for MongoExportStrategy {
-    fn export(self, params: ExportParams) -> Result<()> {
+    fn export(&self, params: ExportParams) -> Result<()> {
         let mut client = Client::with_uri_str(&self.uri)?;
         let sampler = Sampler::try_from(&params.namespace)?;
         let output =

--- a/synth/src/cli/mongo.rs
+++ b/synth/src/cli/mongo.rs
@@ -31,7 +31,7 @@ pub struct MongoImportStrategy {
 }
 
 impl ImportStrategy for MongoImportStrategy {
-    fn import(self) -> Result<Namespace> {
+    fn import(&self) -> Result<Namespace> {
         let client_options = ClientOptions::parse(&self.uri)?;
 
         info!("Connecting to database at {} ...", &self.uri);
@@ -89,14 +89,14 @@ impl ImportStrategy for MongoImportStrategy {
         Ok(namespace)
     }
 
-    fn import_collection(self, name: &Name) -> Result<Content> {
+    fn import_collection(&self, name: &Name) -> Result<Content> {
         self.import()?
             .collections
             .remove(name)
             .ok_or_else(|| anyhow!("Could not find table '{}' in MongoDb database.", name))
     }
 
-    fn into_value(self) -> Result<JsonValue> {
+    fn into_value(&self) -> Result<JsonValue> {
         unreachable!()
     }
 }

--- a/synth/src/cli/mongo.rs
+++ b/synth/src/cli/mongo.rs
@@ -96,7 +96,7 @@ impl ImportStrategy for MongoImportStrategy {
             .ok_or_else(|| anyhow!("Could not find table '{}' in MongoDb database.", name))
     }
 
-    fn into_value(&self) -> Result<JsonValue> {
+    fn as_value(&self) -> Result<JsonValue> {
         unreachable!()
     }
 }

--- a/synth/src/cli/mysql.rs
+++ b/synth/src/cli/mysql.rs
@@ -27,20 +27,20 @@ pub struct MySqlImportStrategy {
 }
 
 impl ImportStrategy for MySqlImportStrategy {
-    fn import(self) -> Result<Namespace> {
+    fn import(&self) -> Result<Namespace> {
         let datasource = MySqlDataSource::new(&self.uri)?;
 
         build_namespace_import(&datasource)
     }
 
-    fn import_collection(self, name: &Name) -> Result<Content> {
+    fn import_collection(&self, name: &Name) -> Result<Content> {
         self.import()?
             .collections
             .remove(name)
             .ok_or_else(|| anyhow!("Could not find table '{}' in Postgres database.", name))
     }
 
-    fn into_value(self) -> Result<Value> {
+    fn into_value(&self) -> Result<Value> {
         bail!("MySql import doesn't support conversion into value")
     }
 }

--- a/synth/src/cli/mysql.rs
+++ b/synth/src/cli/mysql.rs
@@ -40,7 +40,7 @@ impl ImportStrategy for MySqlImportStrategy {
             .ok_or_else(|| anyhow!("Could not find table '{}' in Postgres database.", name))
     }
 
-    fn into_value(&self) -> Result<Value> {
+    fn as_value(&self) -> Result<Value> {
         bail!("MySql import doesn't support conversion into value")
     }
 }

--- a/synth/src/cli/mysql.rs
+++ b/synth/src/cli/mysql.rs
@@ -14,7 +14,7 @@ pub struct MySqlExportStrategy {
 }
 
 impl ExportStrategy for MySqlExportStrategy {
-    fn export(self, params: ExportParams) -> Result<()> {
+    fn export(&self, params: ExportParams) -> Result<()> {
         let datasource = MySqlDataSource::new(&self.uri)?;
 
         create_and_insert_values(params, &datasource)

--- a/synth/src/cli/postgres.rs
+++ b/synth/src/cli/postgres.rs
@@ -1,7 +1,7 @@
 use crate::cli::export::{create_and_insert_values, ExportParams, ExportStrategy};
 use crate::cli::import::ImportStrategy;
 use crate::cli::import_utils::build_namespace_import;
-use crate::datasource::postgres_datasource::PostgresDataSource;
+use crate::datasource::postgres_datasource::{PostgresDataSource, PostgresConnectParams};
 use crate::datasource::DataSource;
 use anyhow::Result;
 use serde_json::Value;
@@ -15,7 +15,12 @@ pub struct PostgresExportStrategy {
 
 impl ExportStrategy for PostgresExportStrategy {
     fn export(self, params: ExportParams) -> Result<()> {
-        let datasource = PostgresDataSource::new(&self.uri)?;
+        let connect_params = PostgresConnectParams {
+            uri: self.uri,
+            schema: None // TODO
+        };
+
+        let datasource = PostgresDataSource::new(&connect_params)?;
 
         create_and_insert_values(params, &datasource)
     }
@@ -24,23 +29,29 @@ impl ExportStrategy for PostgresExportStrategy {
 #[derive(Clone, Debug)]
 pub struct PostgresImportStrategy {
     pub uri: String,
+    pub schema: Option<String>
 }
 
 impl ImportStrategy for PostgresImportStrategy {
-    fn import(self) -> Result<Namespace> {
-        let datasource = PostgresDataSource::new(&self.uri)?;
+    fn import(&self) -> Result<Namespace> {
+        let connect_params = PostgresConnectParams {
+            uri: self.uri.clone(),
+            schema: self.schema.clone()
+        };
+
+        let datasource = PostgresDataSource::new(&connect_params)?;
 
         build_namespace_import(&datasource)
     }
 
-    fn import_collection(self, name: &Name) -> Result<Content> {
+    fn import_collection(&self, name: &Name) -> Result<Content> {
         self.import()?
             .collections
             .remove(name)
             .ok_or_else(|| anyhow!("Could not find table '{}' in Postgres database.", name))
     }
 
-    fn into_value(self) -> Result<Value> {
+    fn into_value(&self) -> Result<Value> {
         bail!("Postgres import doesn't support conversion into value")
     }
 }

--- a/synth/src/cli/postgres.rs
+++ b/synth/src/cli/postgres.rs
@@ -52,7 +52,7 @@ impl ImportStrategy for PostgresImportStrategy {
             .ok_or_else(|| anyhow!("Could not find table '{}' in Postgres database.", name))
     }
 
-    fn into_value(&self) -> Result<Value> {
+    fn as_value(&self) -> Result<Value> {
         bail!("Postgres import doesn't support conversion into value")
     }
 }

--- a/synth/src/cli/postgres.rs
+++ b/synth/src/cli/postgres.rs
@@ -11,13 +11,14 @@ use synth_core::{Content, Name};
 #[derive(Clone, Debug)]
 pub struct PostgresExportStrategy {
     pub uri: String,
+    pub schema: Option<String>
 }
 
 impl ExportStrategy for PostgresExportStrategy {
-    fn export(self, params: ExportParams) -> Result<()> {
+    fn export(&self, params: ExportParams) -> Result<()> {
         let connect_params = PostgresConnectParams {
-            uri: self.uri,
-            schema: None // TODO
+            uri: self.uri.clone(),
+            schema: self.schema.clone()
         };
 
         let datasource = PostgresDataSource::new(&connect_params)?;

--- a/synth/src/cli/stdf.rs
+++ b/synth/src/cli/stdf.rs
@@ -20,7 +20,7 @@ pub struct StdinImportStrategy {}
 pub struct StdoutExportStrategy {}
 
 impl ExportStrategy for StdoutExportStrategy {
-    fn export(self, params: ExportParams) -> Result<()> {
+    fn export(&self, params: ExportParams) -> Result<()> {
         let generator = Sampler::try_from(&params.namespace)?;
         let output = generator.sample_seeded(params.collection_name, params.target, params.seed)?;
         println!("{}", output.into_json());

--- a/synth/src/cli/stdf.rs
+++ b/synth/src/cli/stdf.rs
@@ -29,22 +29,22 @@ impl ExportStrategy for StdoutExportStrategy {
 }
 
 impl ImportStrategy for FileImportStrategy {
-    fn import_collection(self, name: &Name) -> Result<Content> {
+    fn import_collection(&self, name: &Name) -> Result<Content> {
         self.import()?
             .collections
             .remove(name)
             .ok_or_else(|| anyhow!("Could not find collection '{}' in file.", name))
     }
 
-    fn into_value(self) -> Result<Value> {
+    fn into_value(&self) -> Result<Value> {
         Ok(serde_json::from_reader(std::fs::File::open(
-            self.from_file,
+            self.from_file.clone(),
         )?)?)
     }
 }
 
 impl ImportStrategy for StdinImportStrategy {
-    fn into_value(self) -> Result<Value> {
+    fn into_value(&self) -> Result<Value> {
         Ok(serde_json::from_reader(std::io::stdin())?)
     }
 }

--- a/synth/src/cli/stdf.rs
+++ b/synth/src/cli/stdf.rs
@@ -36,7 +36,7 @@ impl ImportStrategy for FileImportStrategy {
             .ok_or_else(|| anyhow!("Could not find collection '{}' in file.", name))
     }
 
-    fn into_value(&self) -> Result<Value> {
+    fn as_value(&self) -> Result<Value> {
         Ok(serde_json::from_reader(std::fs::File::open(
             self.from_file.clone(),
         )?)?)
@@ -44,7 +44,7 @@ impl ImportStrategy for FileImportStrategy {
 }
 
 impl ImportStrategy for StdinImportStrategy {
-    fn into_value(&self) -> Result<Value> {
+    fn as_value(&self) -> Result<Value> {
         Ok(serde_json::from_reader(std::io::stdin())?)
     }
 }

--- a/synth/src/datasource/mysql_datasource.rs
+++ b/synth/src/datasource/mysql_datasource.rs
@@ -70,6 +70,11 @@ impl RelationalDataSource for MySqlDataSource {
         Ok(result)
     }
 
+    async fn set_schema(&self) -> Result<()> {
+        // no-op since MySQL doesn't have a concept of a schema
+        Ok(())
+    }
+
     async fn get_table_names(&self) -> Result<Vec<String>> {
         let query = r"SELECT table_name FROM information_schema.tables
             WHERE table_schema = DATABASE() and table_type = 'BASE TABLE'";

--- a/synth/src/datasource/mysql_datasource.rs
+++ b/synth/src/datasource/mysql_datasource.rs
@@ -70,11 +70,6 @@ impl RelationalDataSource for MySqlDataSource {
         Ok(result)
     }
 
-    async fn set_schema(&self) -> Result<()> {
-        // no-op since MySQL doesn't have a concept of a schema
-        Ok(())
-    }
-
     async fn get_table_names(&self) -> Result<Vec<String>> {
         let query = r"SELECT table_name FROM information_schema.tables
             WHERE table_schema = DATABASE() and table_type = 'BASE TABLE'";

--- a/synth/src/datasource/postgres_datasource.rs
+++ b/synth/src/datasource/postgres_datasource.rs
@@ -85,11 +85,11 @@ impl DataSource for PostgresDataSource {
 }
 
 impl PostgresDataSource {
-    async fn check_schema_exists(pool: &Pool<Postgres>, schema: &String) -> Result<()> {
-        // select schema_name from information_schema.schemata where catalog_name = current_catalog ;
+    async fn check_schema_exists(pool: &Pool<Postgres>, schema: &str) -> Result<()> {
         let query = r"SELECT schema_name
         FROM information_schema.schemata
         WHERE catalog_name = current_catalog;";
+
         let available_schemas: Vec<String> = sqlx::query(query)
             .fetch_all(pool)
             .await?
@@ -97,7 +97,7 @@ impl PostgresDataSource {
             .map(|row| row.get(0))
             .collect();
 
-        if !available_schemas.contains(schema) {
+        if !available_schemas.contains(&schema.to_string()) {
             let formatted_schemas = available_schemas.join(", ");
             bail!("the schema '{}' could not be found on the database. Available schemas are: {}.", schema, formatted_schemas);
         }

--- a/synth/src/datasource/postgres_datasource.rs
+++ b/synth/src/datasource/postgres_datasource.rs
@@ -97,21 +97,6 @@ impl RelationalDataSource for PostgresDataSource {
         Ok(result)
     }
 
-    async fn set_schema(&self) -> Result<()> {
-        // let query = format!("SET search_path = {}", self.schema);
-        //
-        // sqlx::query(&query)
-        //     .execute(&self.single_thread_pool)
-        //     .await?;
-        //
-        //
-        // sqlx::query(&query)
-        //     .execute(&self.pool)
-        //     .await?;
-
-        Ok(())
-    }
-
     async fn get_table_names(&self) -> Result<Vec<String>> {
         let query = r"SELECT table_name
         FROM information_schema.tables

--- a/synth/src/datasource/relational_datasource.rs
+++ b/synth/src/datasource/relational_datasource.rs
@@ -51,8 +51,6 @@ pub trait RelationalDataSource: DataSource {
         collection: &[Value],
     ) -> Result<()> {
 
-        self.set_schema().await?;
-
         let batch_size = DEFAULT_INSERT_BATCH_SIZE;
 
         if collection.is_empty() {
@@ -138,8 +136,6 @@ pub trait RelationalDataSource: DataSource {
         query: String,
         query_params: Vec<&Value>,
     ) -> Result<Self::QueryResult>;
-
-    async fn set_schema(&self) -> Result<()>;
 
     async fn get_table_names(&self) -> Result<Vec<String>>;
 

--- a/synth/src/datasource/relational_datasource.rs
+++ b/synth/src/datasource/relational_datasource.rs
@@ -126,6 +126,7 @@ pub trait RelationalDataSource: DataSource {
 
         if let Err(e) = results.into_iter().bcollect::<Vec<Self::QueryResult>>() {
             bail!("One or more database inserts failed: {:?}", e)
+
         }
 
         info!("Inserted {} rows...", collection.len());

--- a/synth/src/datasource/relational_datasource.rs
+++ b/synth/src/datasource/relational_datasource.rs
@@ -135,6 +135,8 @@ pub trait RelationalDataSource: DataSource {
         query_params: Vec<&Value>,
     ) -> Result<Self::QueryResult>;
 
+    async fn set_schema(&self) -> Result<()>;
+
     async fn get_table_names(&self) -> Result<Vec<String>>;
 
     async fn get_columns_infos(&self, table_name: &str) -> Result<Vec<ColumnInfo>>;

--- a/synth/src/datasource/relational_datasource.rs
+++ b/synth/src/datasource/relational_datasource.rs
@@ -50,6 +50,9 @@ pub trait RelationalDataSource: DataSource {
         collection_name: String,
         collection: &[Value],
     ) -> Result<()> {
+
+        self.set_schema().await?;
+
         let batch_size = DEFAULT_INSERT_BATCH_SIZE;
 
         if collection.is_empty() {


### PR DESCRIPTION
**Summary of Changes**

This PR introduces the idea of a schema to our Postgres support. Schemas are a logical way that Postgres splits up catalogs (databases basically). 

**Old Behavior**

The default schema is `public` when you connect to a PG database and you couldn't specify a schema to connect to. Furthermore the lack of specifying the schema meant that queries which would get primary keys foreign keys etc wouldn't be targeted at a specific schema so things would break.

**New Behavior**

Optionally the schema is specified at the CLI level for import and generate - if no schema is specified it defaults to `public`. When the connection to the database is established there is an explicit check done to see if the schema exists. If it does not a helpful error message tells you so. This schema is then used by the integration via:
1. the connection level. It needs to be set for both connection pools separately as they have their own contents. This is done at ~`postgres_datasource.rs:30`.
2. at the query level we specify `table_schema` explicitly when trying to figure out primary keys, foreign keys etc.

**Other Bits**

I also refactored the `Import/Export` strategy code to work with `Box<dyn ImportStrategy>` instead of having the super enum `SomeImportStrategy`. This was a consequence of the Import/Export strategies not being instantiated as a CLI arg any more.

A few things left todo:

- [x] Fix some non-determinism with `set_schema` on the thread pool
- [ ] Add tests which have more than one schema
- [x] Document the schema parameter in the integrations docs