### PR TITLE
feat: support sqlite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,6 +1649,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libssh2-sys"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2907,6 +2918,7 @@ dependencies = [
  "hmac 0.10.1",
  "itoa",
  "libc",
+ "libsqlite3-sys",
  "log",
  "md-5",
  "memchr",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,4 +35,4 @@ bimap = { version = "0.6.0", features = [ "std" ] }
 humantime-serde = "1.0.1"
 bloomfilter = "1.0.5"
 dynfmt = { version = "0.1.5", features = [ "curly" ] }
-sqlx = { version = "0.5.7", features = [ "postgres", "mysql", "runtime-async-std-native-tls", "decimal", "chrono" ] }
+sqlx = { version = "0.5.7", features = [ "sqlite", "postgres", "mysql", "runtime-async-std-native-tls", "decimal", "chrono" ] }

--- a/synth/Cargo.toml
+++ b/synth/Cargo.toml
@@ -73,7 +73,7 @@ indicatif = "0.15.0"
 dirs = "3.0.2"
 mongodb = {version = "2.0.0-beta.3", features = ["sync", "bson-chrono-0_4"] , default-features = false}
 
-sqlx = { version = "0.5.7", features = [ "postgres", "mysql", "runtime-async-std-native-tls", "decimal", "chrono" ] }
+sqlx = { version = "0.5.7", features = [ "sqlite", "postgres", "mysql", "runtime-async-std-native-tls", "decimal", "chrono" ] }
 
 beau_collector = "0.2.1"
 

--- a/synth/src/cli/export.rs
+++ b/synth/src/cli/export.rs
@@ -6,6 +6,7 @@ use std::convert::TryFrom;
 
 use crate::cli::mongo::MongoExportStrategy;
 use crate::cli::mysql::MySqlExportStrategy;
+use crate::cli::sqlite::SqliteExportStrategy;
 use crate::datasource::DataSource;
 use crate::sampler::{Sampler, SamplerOutput};
 use async_std::task;
@@ -47,9 +48,13 @@ impl TryFrom<DataSourceParams> for Box<dyn ExportStrategy> {
                     Box::new(MySqlExportStrategy {
                         uri
                     })
+                } else if uri.starts_with("sqlite://")  {
+                    Box::new(SqliteExportStrategy {
+                        uri
+                    })
                 } else {
                     return Err(anyhow!(
-                            "Data sink not recognized. Was expecting one of 'mongodb' or 'postgres' or 'mysql' or 'mariadb'"
+                        "Data sink not recognized. Was expecting one of 'mongodb' or 'postgres' or 'mysql' or 'sqlite' or 'mariadb'"
                     ));
                 };
                 Ok(export_strategy)

--- a/synth/src/cli/import.rs
+++ b/synth/src/cli/import.rs
@@ -12,8 +12,10 @@ use synth_core::schema::Namespace;
 use crate::cli::db_utils::DataSourceParams;
 use crate::cli::mongo::MongoImportStrategy;
 use crate::cli::mysql::MySqlImportStrategy;
+use crate::cli::sqlite::SqliteImportStrategy;
 use crate::cli::postgres::PostgresImportStrategy;
 use crate::cli::stdf::{FileImportStrategy, StdinImportStrategy};
+
 
 pub trait ImportStrategy {
     fn import(&self) -> Result<Namespace> {
@@ -43,6 +45,10 @@ impl TryFrom<DataSourceParams> for Box<dyn ImportStrategy> {
                     })
                 } else if uri.starts_with("mysql://") || uri.starts_with("mariadb://") {
                     Box::new(MySqlImportStrategy {
+                        uri,
+                    })
+                } else if uri.starts_with("sqlite://") {
+                    Box::new(SqliteImportStrategy {
                         uri,
                     })
                 } else if let Ok(path) = PathBuf::from_str(&uri) {

--- a/synth/src/cli/mod.rs
+++ b/synth/src/cli/mod.rs
@@ -137,9 +137,9 @@ impl Cli {
                 self.store.save_collection_path(&path, collection, content)?;
                 Ok(())
             }
-        } else if self.store.ns_exists(&path) {
+        } else if self.store.ns_exists(&path) && !self.store.ns_is_empty_dir(&path) {
             Err(anyhow!(
-                "The directory at `{}` already exists. Will not import into an existing directory.",
+                "The directory at `{}` already exists and is not empty. Will not import into an existing directory.",
                 path.display()
             ))
         } else {

--- a/synth/src/cli/mod.rs
+++ b/synth/src/cli/mod.rs
@@ -3,6 +3,7 @@ mod import;
 mod import_utils;
 mod mongo;
 mod mysql;
+mod sqlite;
 mod postgres;
 mod stdf;
 mod store;

--- a/synth/src/cli/sqlite.rs
+++ b/synth/src/cli/sqlite.rs
@@ -1,0 +1,46 @@
+use crate::cli::export::{create_and_insert_values, ExportParams, ExportStrategy};
+use crate::cli::import::ImportStrategy;
+use crate::cli::import_utils::build_namespace_import;
+use crate::datasource::sqlite_datasource::SqliteDataSource;
+use crate::datasource::DataSource;
+use anyhow::Result;
+use serde_json::Value;
+use synth_core::schema::Namespace;
+use synth_core::{Content, Name};
+
+#[derive(Clone, Debug)]
+pub struct SqliteExportStrategy {
+    pub uri: String,
+}
+
+impl ExportStrategy for SqliteExportStrategy {
+    fn export(&self, params: ExportParams) -> Result<()> {
+        let datasource = SqliteDataSource::new(&self.uri)?;
+
+        create_and_insert_values(params, &datasource)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SqliteImportStrategy {
+    pub uri: String,
+}
+
+impl ImportStrategy for SqliteImportStrategy {
+    fn import(&self) -> Result<Namespace> {
+        let datasource = SqliteDataSource::new(&self.uri)?;
+
+        build_namespace_import(&datasource)
+    }
+
+    fn import_collection(&self, name: &Name) -> Result<Content> {
+        self.import()?
+            .collections
+            .remove(name)
+            .ok_or_else(|| anyhow!("Could not find table '{}' in Sqlite database.", name))
+    }
+
+    fn as_value(&self) -> Result<Value> {
+        bail!("Sqlite import doesn't support conversion into value")
+    }
+}

--- a/synth/src/cli/store.rs
+++ b/synth/src/cli/store.rs
@@ -64,6 +64,11 @@ impl Store {
         self.ns_path(namespace).exists()
     }
 
+    pub fn ns_is_empty_dir(&self, namespace: &Path) -> bool {
+        self.ns_path(namespace).is_dir() 
+            && self.ns_path(namespace).read_dir().map(|mut dir| dir.next().is_none()).unwrap_or_default()
+    }
+
     pub fn collection_exists(&self, namespace: &Path, collection: &Name) -> bool {
         self.collection_path(namespace, collection).exists()
     }

--- a/synth/src/datasource/mod.rs
+++ b/synth/src/datasource/mod.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use synth_core::Value;
 
+pub(crate) mod sqlite_datasource;
 pub(crate) mod mysql_datasource;
 pub(crate) mod postgres_datasource;
 pub(crate) mod relational_datasource;

--- a/synth/src/datasource/sqlite_datasource.rs
+++ b/synth/src/datasource/sqlite_datasource.rs
@@ -1,0 +1,300 @@
+use crate::datasource::relational_datasource::{
+    ColumnInfo, ForeignKey, PrimaryKey, RelationalDataSource, ValueWrapper,
+};
+use crate::datasource::DataSource;
+use anyhow::{Context, Result};
+use async_std::task;
+use async_trait::async_trait;
+use rust_decimal::prelude::ToPrimitive;
+use sqlx::sqlite::{SqliteColumn, SqlitePoolOptions, SqliteQueryResult, SqliteRow};
+use sqlx::{Column, Pool, Row, Sqlite, TypeInfo};
+use std::collections::BTreeMap;
+use std::convert::TryFrom;
+use std::prelude::rust_2015::Result::Ok;
+use synth_core::schema::number_content::{F64, I64};
+use synth_core::schema::{
+    BoolContent, ChronoValueType, DateTimeContent, NullContent, NumberContent, RangeStep,
+    RegexContent, StringContent,
+};
+use synth_core::{Content, Value};
+use synth_gen::prelude::*;
+
+/// TODO
+/// Known issues:
+/// - Sqlite's random implementation does not support a seed argument. We currently use `random` directly.
+/// This makes the sampling not behave as intended.
+
+pub struct SqliteDataSource {
+    pool: Pool<Sqlite>,
+}
+
+#[async_trait]
+impl DataSource for SqliteDataSource {
+    type ConnectParams = String;
+
+    fn new(connect_params: &Self::ConnectParams) -> Result<Self> {
+        task::block_on(async {
+            use sqlx::migrate::MigrateDatabase;
+            if !sqlx::Sqlite::database_exists(connect_params.as_str()).await? {
+                sqlx::Sqlite::create_database(connect_params.as_str()).await?;
+            }
+
+            let pool = SqlitePoolOptions::new()
+                .max_connections(3) //TODO expose this as a user config?
+                .connect(connect_params.as_str())
+                .await?;
+
+            Ok::<Self, anyhow::Error>(SqliteDataSource { pool })
+        })
+    }
+
+    async fn insert_data(&self, collection_name: String, collection: &[Value]) -> Result<()> {
+        self.insert_relational_data(collection_name, collection)
+            .await
+    }
+}
+
+#[async_trait]
+impl RelationalDataSource for SqliteDataSource {
+    type QueryResult = SqliteQueryResult;
+
+    async fn execute_query(
+        &self,
+        query: String,
+        query_params: Vec<&Value>,
+    ) -> Result<SqliteQueryResult> {
+        let mut query = sqlx::query(query.as_str());
+
+        for param in query_params {
+            query = query.bind(param);
+        }
+
+        let result = query.execute(&self.pool).await?;
+
+        Ok(result)
+    }
+
+    async fn get_table_names(&self) -> Result<Vec<String>> {
+        let query = r"SELECT name FROM sqlite_master
+            WHERE type='table'";
+
+        let table_names: Vec<String> = sqlx::query(query)
+            .fetch_all(&self.pool)
+            .await?
+            .iter()
+            .map(|row| row.get::<String, usize>(0))
+            .collect();
+
+        Ok(table_names)
+    }
+
+    async fn get_columns_infos(&self, table_name: &str) -> Result<Vec<ColumnInfo>> {
+        let query = r"SELECT * FROM PRAGMA_TABLE_INFO(?)";
+
+        let column_infos = sqlx::query(query)
+            .bind(table_name)
+            .fetch_all(&self.pool)
+            .await?
+            .into_iter()
+            .map(ColumnInfo::try_from)
+            .collect::<Result<Vec<ColumnInfo>>>()?;
+
+        Ok(column_infos)
+    }
+
+    async fn get_primary_keys(&self, table_name: &str) -> Result<Vec<PrimaryKey>> {
+        let query: &str = r"SELECT name, type FROM pragma_table_info(?) WHERE pk = 1";
+
+        sqlx::query(query)
+            .bind(table_name)
+            .fetch_all(&self.pool)
+            .await?
+            .into_iter()
+            .map(PrimaryKey::try_from)
+            .collect::<Result<Vec<PrimaryKey>>>()
+    }
+
+    async fn get_foreign_keys(&self) -> Result<Vec<ForeignKey>> {
+        let query: &str = r"SELECT * FROM pragma_table_info(?)";
+
+        sqlx::query(query)
+            .fetch_all(&self.pool)
+            .await?
+            .into_iter()
+            .map(ForeignKey::try_from)
+            .collect::<Result<Vec<ForeignKey>>>()
+    }
+
+    async fn set_seed(&self) -> Result<()> {
+        // Sqlite doesn't set seed in a separate query
+        Ok(())
+    }
+
+    async fn get_deterministic_samples(&self, table_name: &str) -> Result<Vec<Value>> {
+        // FIXME:(rasviitanen) [2021-10-03] The random implementation doesn't take a seed
+        // in Sqlite, should we use rust's rand instead?
+        let query: &str = &format!("SELECT * FROM {} ORDER BY random() LIMIT 10", table_name);
+
+        let values = sqlx::query(query)
+            .fetch_all(&self.pool)
+            .await?
+            .into_iter()
+            .map(ValueWrapper::try_from)
+            .map(|v| match v {
+                Ok(wrapper) => Ok(wrapper.0),
+                Err(e) => bail!(
+                    "Failed to convert to value wrapper from query results: {:?}",
+                    e
+                ),
+            })
+            .collect::<Result<Vec<Value>>>()?;
+
+        Ok(values)
+    }
+
+    fn decode_to_content(&self, data_type: &str, char_max_len: Option<i32>) -> Result<Content> {
+        let content = match data_type.to_lowercase().as_str() {
+            "boolean" => {
+                Content::Bool(BoolContent::default())
+            }
+            "integer" => {
+                Content::Number(NumberContent::I64(I64::Range(RangeStep::default())))
+            }
+            "int8" | "bigint" => {
+            // FIXME:(rasviitanen) [2021-10-03] this should be i128, but is fine for now as u64 is not supported yet
+                Content::Number(NumberContent::I64(I64::Range(RangeStep::default())))
+            }
+            "real" => {
+                Content::Number(NumberContent::F64(F64::Range(RangeStep::default())))
+            }
+            "datetime" => {
+                Content::String(StringContent::DateTime(DateTimeContent {
+                    format: "%Y-%m-%d %H:%M:%S".to_string(),
+                    type_: ChronoValueType::NaiveDateTime,
+                    begin: None,
+                    end: None,
+                }))
+            }
+            "blob" | "text" => {
+                let pattern =
+                    "[a-zA-Z0-9]{0, {}}".replace("{}", &format!("{}", char_max_len.unwrap_or(1)));
+                Content::String(StringContent::Pattern(
+                    RegexContent::pattern(pattern).context("pattern will always compile")?,
+                ))
+            }
+            "null" => Content::Null(NullContent),
+            _ => unreachable!(
+                "Missing converter implementation for `{}`, but synth's Sqlite decoder should cover all types. \
+                Please reach out to https://github.com/getsynth/synth/issues if encountered.",
+                data_type
+            ),
+        };
+
+        Ok(content)
+    }
+
+    fn extend_parameterised_query(query: &mut String, _curr_index: usize, extend: usize) {
+        query.push('(');
+        for i in 0..extend {
+            query.push('?');
+            if i != extend - 1 {
+                query.push(',');
+            }
+        }
+        query.push(')');
+    }
+}
+
+impl TryFrom<SqliteRow> for ColumnInfo {
+    type Error = anyhow::Error;
+
+    fn try_from(row: SqliteRow) -> Result<Self, Self::Error> {
+        Ok(ColumnInfo {
+            column_name: row.try_get::<String, usize>(1)?,
+            ordinal_position: row.try_get::<u32, usize>(0)? as i32,
+            is_nullable: !row.try_get::<bool, usize>(3)?,
+            data_type: row.try_get::<String, usize>(2)?,
+            character_maximum_length: None,
+        })
+    }
+}
+
+impl TryFrom<SqliteRow> for PrimaryKey {
+    type Error = anyhow::Error;
+
+    fn try_from(row: SqliteRow) -> Result<Self, Self::Error> {
+        Ok(PrimaryKey {
+            column_name: row.try_get::<String, usize>(0)?,
+            type_name: row.try_get::<String, usize>(1)?,
+        })
+    }
+}
+
+impl TryFrom<SqliteRow> for ForeignKey {
+    type Error = anyhow::Error;
+
+    fn try_from(row: SqliteRow) -> Result<Self, Self::Error> {
+        Ok(ForeignKey {
+            from_table: row.try_get::<String, usize>(0)?,
+            from_column: row.try_get::<String, usize>(1)?,
+            to_table: row.try_get::<String, usize>(2)?,
+            to_column: row.try_get::<String, usize>(3)?,
+        })
+    }
+}
+
+impl TryFrom<SqliteRow> for ValueWrapper {
+    type Error = anyhow::Error;
+
+    fn try_from(row: SqliteRow) -> Result<Self, Self::Error> {
+        let mut kv = BTreeMap::new();
+
+        for column in row.columns() {
+            let value = try_match_value(&row, column).unwrap_or(Value::Null(()));
+            kv.insert(column.name().to_string(), value);
+        }
+
+        Ok(ValueWrapper(Value::Object(kv)))
+    }
+}
+
+fn try_match_value(row: &SqliteRow, column: &SqliteColumn) -> Result<Value> {
+    let value = match column.type_info().name().to_lowercase().as_str() {
+        "boolean" => {
+            Value::Bool(row.try_get::<i8, &str>(column.name())? == 1)
+        }
+        "integer" => {
+            Value::Number(Number::from(row.try_get::<i64, &str>(column.name())?))
+        }
+        "int8" | "bigint" => {
+            // FIXME:(rasviitanen) [2021-10-03] this should be i128, but is fine for now as u64 is not supported yet
+            Value::Number(Number::from(row.try_get::<i64, &str>(column.name())?))
+        }
+        "real" => {
+            let as_decimal = row.try_get::<u32, &str>(column.name())?;
+
+            if let Some(truncated) = as_decimal.to_f64() {
+                return Ok(Value::Number(Number::from(truncated)));
+            }
+
+            bail!("Failed to convert Sqlite real data type to 64 bit float")
+        }
+        "datetime" => Value::String(format!(
+            "{}",
+            row.try_get::<chrono::NaiveDateTime, &str>(column.name())?
+        )),
+        "blob" | "text" => {
+            Value::String(row.try_get::<String, &str>(column.name())?)
+        }
+        "null" => Value::Null(()),
+        _ => {
+            bail!(
+                "Could not convert value. Converter not implemented for {}, but Synth's Sqlite converter should cover all types. \
+                Please reach out to https://github.com/getsynth/synth/issues if encountered.",
+                column.type_info().name()
+            );
+        }
+    };
+
+    Ok(value)
+}


### PR DESCRIPTION
Adds support for sqlite.

closes: #161 

# Todo

- A `test harness` - we should proabably create a test harness at `synth/test_harness/sqlite`
- The random sampling does not work as intended as sqlite's `random` doesn't support a seed.

# Other

- I had some issues when generating to an empty directory, so I added support for this [[commit !85ca11b](https://github.com/getsynth/synth/commit/85ca11b9065b01db6c3e4d5e0f2016cfb12d2532)]
- I had some issues where I had `low=Bound::Included(1)` and  `high=Bound::Excluded(1)`. To me it feels natural that this range includes a number `1`, so I added some code for this [[commit !8ba84fa](https://github.com/getsynth/synth/commit/8ba84faf823f88d7874a2507ed481ae726f6d48d)].

I can drop these two commits if they are not desired.

---

Any maintainers are free to edit and provide feedback.
If you are in a hurry you can take over this MR, otherwise I'll fix the remaining things whenever I find the time to do so.