### PR TITLE
feat: number and dates in string formatter

### DIFF
--- a/core/src/graph/mod.rs
+++ b/core/src/graph/mod.rs
@@ -163,6 +163,7 @@ impl TryFrom<Value> for String {
     fn try_from(value: Value) -> Result<String, Self::Error> {
         match value {
             Value::String(str) => Ok(str),
+            Value::Number(num) => Ok(num.to_string()),
             otherwise => Err(failed_crate!(
                 target: Release,
                 "invalid type: expected 'String', found '{}'",

--- a/core/src/graph/mod.rs
+++ b/core/src/graph/mod.rs
@@ -164,6 +164,7 @@ impl TryFrom<Value> for String {
         match value {
             Value::String(str) => Ok(str),
             Value::Number(num) => Ok(num.to_string()),
+            Value::DateTime(date) => Ok(date.format_to_string()),
             otherwise => Err(failed_crate!(
                 target: Release,
                 "invalid type: expected 'String', found '{}'",

--- a/core/src/graph/mod.rs
+++ b/core/src/graph/mod.rs
@@ -94,23 +94,6 @@ macro_rules! derive_from {
 			Self::$variant(value)
 		    }
 		}
-
-		impl TryInto<$ty> for $id {
-		    type Error = Error;
-		    fn try_into(self) -> Result<$ty, Self::Error> {
-			match self {
-			    Self::$variant(value) => Ok(value),
-			    otherwise => Err(
-				failed_crate!(
-				    target: Release,
-				    "invalid type: expected '{}', found '{}'",
-				    stringify!($variant),
-				    otherwise.type_()
-				)
-			    )
-			}
-		    }
-		}
 	    )?
 	)*
     };
@@ -171,6 +154,36 @@ derive_from! {
         DateTime(ChronoValueAndFormat),
         Object(BTreeMap<String, Value>),
         Array(Vec<Value>),
+    }
+}
+
+impl TryFrom<Value> for String {
+    type Error = Error;
+
+    fn try_from(value: Value) -> Result<String, Self::Error> {
+        match value {
+            Value::String(str) => Ok(str),
+            otherwise => Err(failed_crate!(
+                target: Release,
+                "invalid type: expected 'String', found '{}'",
+                otherwise.type_()
+            )),
+        }
+    }
+}
+
+impl TryFrom<Value> for Number {
+    type Error = Error;
+
+    fn try_from(value: Value) -> Result<Number, Self::Error> {
+        match value {
+            Value::Number(num) => Ok(num),
+            otherwise => Err(failed_crate!(
+                target: Release,
+                "invalid type: expected 'Number', found '{}'",
+                otherwise.type_()
+            )),
+        }
     }
 }
 

--- a/core/src/graph/string/format.rs
+++ b/core/src/graph/string/format.rs
@@ -86,7 +86,7 @@ impl dynfmt::FormatArgs for FormatArgs<String> {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::graph::{Graph, RandFaker, RandomString, StringNode};
+    use crate::graph::{Graph, NumberNode, RandFaker, RandomI64, RandomString, StringNode};
 
     fn faker_graph(name: &str) -> Graph {
         Graph::String(StringNode::from(RandomString::from(
@@ -128,6 +128,28 @@ pub mod tests {
             ..Default::default()
         };
         let formatted = Format::new("my email is {} and my username is {}".to_string(), args);
+        formatted
+            .repeat(1024)
+            .complete(&mut rng)
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+    }
+
+    #[test]
+    fn format_with_number_args() {
+        let mut rng = rand::thread_rng();
+
+        let args = FormatArgs {
+            named: vec![(
+                "id".to_string(),
+                Graph::Number(NumberNode::from(RandomI64::constant(42))),
+            )]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        };
+        let formatted = Format::new("{id}_suffix".to_string(), args);
         formatted
             .repeat(1024)
             .complete(&mut rng)

--- a/core/src/graph/string/format.rs
+++ b/core/src/graph/string/format.rs
@@ -86,7 +86,11 @@ impl dynfmt::FormatArgs for FormatArgs<String> {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::graph::{Graph, NumberNode, RandFaker, RandomI64, RandomString, StringNode};
+    use crate::graph::{
+        ChronoValue, Graph, NumberNode, RandFaker, RandomDateTime, RandomI64, RandomString,
+        StringNode,
+    };
+    use chrono::naive::NaiveDate;
 
     fn faker_graph(name: &str) -> Graph {
         Graph::String(StringNode::from(RandomString::from(
@@ -158,5 +162,33 @@ pub mod tests {
             .unwrap();
 
         assert_eq!(gen[0], "42_suffix");
+    }
+
+    #[test]
+    fn format_with_date_args() {
+        let mut rng = rand::thread_rng();
+
+        let args = FormatArgs {
+            named: vec![(
+                "date".to_string(),
+                Graph::String(StringNode::from(RandomDateTime::new(
+                    ChronoValue::NaiveDate(NaiveDate::from_ymd(2021, 10, 4))
+                        ..ChronoValue::NaiveDate(NaiveDate::from_ymd(2021, 10, 4)),
+                    "%Y-%m-%d",
+                ))),
+            )]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        };
+        let formatted = Format::new("{date}.png".to_string(), args);
+        let gen = formatted
+            .repeat(1024)
+            .complete(&mut rng)
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        assert_eq!(gen[0], "2021-10-04.png");
     }
 }

--- a/core/src/graph/string/format.rs
+++ b/core/src/graph/string/format.rs
@@ -150,11 +150,13 @@ pub mod tests {
             ..Default::default()
         };
         let formatted = Format::new("{id}_suffix".to_string(), args);
-        formatted
+        let gen = formatted
             .repeat(1024)
             .complete(&mut rng)
             .into_iter()
             .collect::<Result<Vec<_>, _>>()
             .unwrap();
+
+        assert_eq!(gen[0], "42_suffix");
     }
 }

--- a/gen/src/error.rs
+++ b/gen/src/error.rs
@@ -11,10 +11,10 @@ pub enum Error {
 }
 
 impl Error {
-    pub fn type_<T1: ToString, T2: ToString>(expected: T1, got: T2) -> Self {
+    pub fn type_<T1: ToString, T2: Debug>(expected: T1, got: T2) -> Self {
         Self::Type {
             expected: expected.to_string(),
-            got: got.to_string(),
+            got: format!("{:?}", got),
         }
     }
 

--- a/gen/src/error.rs
+++ b/gen/src/error.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::fmt::{Display, Debug};
 
 use crate::value::{IntoToken, Special, Token};
 

--- a/gen/src/value.rs
+++ b/gen/src/value.rs
@@ -35,7 +35,7 @@ macro_rules! generate_enum {
 	    )*
 	}
 
-	impl std::fmt::Display for $id {
+	impl std::fmt::Debug for $id {
 	    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {
 		    $(
@@ -144,7 +144,7 @@ macro_rules! generate_special_enum {
 			    Token::$id($id::$variant$(($($var,)*))?) => Ok(($($($var,)*)*)),
 			    otherwise => {
 				let err = format!(
-				    "unexpected: wanted {}, got {}",
+				    "unexpected: wanted {}, got {:?}",
 				    stringify!($variant),
 				    otherwise
 				);
@@ -216,7 +216,7 @@ macro_rules! data_model_variant_impl_ext {
 generate_enum!(
     /// Token variant for serde primitive numerical types.
     #[allow(missing_docs)]
-    #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+    #[derive(Clone, Copy, Hash, PartialEq, Eq)]
     pub enum Number {
         I8(i8),
         I16(i16),
@@ -290,7 +290,7 @@ impl serde::Serialize for Number {
 generate_enum!(
     /// Token variant for all serde primitive (non-composite) types.
     #[allow(missing_docs)]
-    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+    #[derive(Clone, PartialEq, Eq, Hash)]
     pub enum Primitive {
         Bool(bool),
         String(String),
@@ -342,7 +342,7 @@ generate_special_enum!(
 
 generate_enum!(
     /// A custom tokenization for the serde data model.
-    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+    #[derive(Clone, PartialEq, Eq, Hash)]
     pub enum Token {
         /// A token encoding serde primitive types.
         Primitive(Primitive),

--- a/gen/src/value.rs
+++ b/gen/src/value.rs
@@ -35,6 +35,16 @@ macro_rules! generate_enum {
 	    )*
 	}
 
+	impl std::fmt::Display for $id {
+	    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+		    $(
+			Self::$variant(inner) => write!(f, "{:?}", inner),
+		    )*
+		}
+	    }
+	}
+
 	impl std::fmt::Debug for $id {
 	    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {


### PR DESCRIPTION
Adds number capabilities to string formatter to close #169.

This is done by switching the `TryInto` to a `TryFrom` specifically for strings. It then uses the `to_string` on Numbers to convert them to string. Unfortunately the current `Display` implementation contained some extra parenthesis and type information. So this `Display` was swapped to `Debug` and all callers updated. Then a new minimal `Display` is added. In the end one extra line also makes it possible to use DateTime with the string formatter.

 An extra `TryFrom` also had to be added for Numbers.