### PR TITLE
refactor: format all the declarative macros

### DIFF
--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -2,43 +2,43 @@ use serde::{Deserialize, Serialize};
 
 macro_rules! generate_error_variants {
     {
-	$(#[$attr:meta])*
-	$vis:vis enum $id:ident {
-	    $(
-		$(#[$variant_attr:meta])*
-		$variant:ident -> $func_name:ident,
-	    )*
-	}
+        $(#[$attr:meta])*
+        $vis:vis enum $id:ident {
+            $(
+                $(#[$variant_attr:meta])*
+                $variant:ident -> $func_name:ident,
+            )*
+        }
     } => {
-	$(#[$attr])*
-	$vis enum $id {
-	    $(
-		$(#[$variant_attr])*
-		$variant,
-	    )*
-	}
+        $(#[$attr])*
+        $vis enum $id {
+            $(
+                $(#[$variant_attr])*
+                $variant,
+            )*
+        }
 
- 	impl Error {
-	    $(
-		#[inline]
-		pub fn $func_name<R: AsRef<str>>(msg: R) -> Self {
-	            Self::new($id::$variant, msg, crate::error::Target::Debug)
-		}
-	    )*
-	}
+        impl Error {
+            $(
+                #[inline]
+                pub fn $func_name<R: AsRef<str>>(msg: R) -> Self {
+                    Self::new($id::$variant, msg, crate::error::Target::Debug)
+                }
+            )*
+        }
     }
 }
 
 macro_rules! failed_crate {
     (target: $target:ident, $lit: literal$(, $arg:expr)*) => {
-	failed_crate!(target: $target, BadRequest => $lit$(, $arg)*)
+        failed_crate!(target: $target, BadRequest => $lit$(, $arg)*)
     };
     (target: $target:ident, $variant:ident => $lit:literal$(, $arg:expr)*) => {
-	crate::error::Error::new(
-	    crate::error::ErrorKind::$variant,
-	    format!($lit$(, $arg)*),
-	    crate::error::Target::$target
-	)
+        crate::error::Error::new(
+            crate::error::ErrorKind::$variant,
+            format!($lit$(, $arg)*),
+            crate::error::Target::$target
+        )
     };
 }
 
@@ -53,12 +53,12 @@ macro_rules! failed_crate {
 ///     2) The generator graph (distributions, detected cycles, malformed generators, etc.)
 macro_rules! failed {
     (target: $target:ident, $lit: literal$(, $arg:expr)*) => {
-	failed!(target: $target, BadRequest => $lit$(, $arg)*)
+        failed!(target: $target, BadRequest => $lit$(, $arg)*)
     };
     (target: $target:ident, $variant:ident => $lit:literal$(, $arg:expr)*) => {
-	anyhow::Error::from(
-	    failed_crate!(target: $target, $variant => $lit$(,$arg)*)
-	)
+        anyhow::Error::from(
+            failed_crate!(target: $target, $variant => $lit$(,$arg)*)
+        )
     };
 }
 

--- a/core/src/graph/boolean.rs
+++ b/core/src/graph/boolean.rs
@@ -6,9 +6,9 @@ derive_generator! {
     yield bool,
     return Never,
     pub enum RandomBool {
-    Bernoulli(Random<bool, Bernoulli>),
-    Constant(Yield<bool>),
-    Categorical(Random<bool, Categorical<bool>>),
+        Bernoulli(Random<bool, Bernoulli>),
+        Constant(Yield<bool>),
+        Categorical(Random<bool, Categorical<bool>>),
     }
 }
 

--- a/core/src/graph/mod.rs
+++ b/core/src/graph/mod.rs
@@ -73,33 +73,33 @@ pub type OnceInfallible<G> = TryOnce<Infallible<G, Error>>;
 
 macro_rules! derive_from {
     {
-	#[$attr:meta]
-	$vis:vis enum $id:ident {
-	    $($variant:ident$(($ty:ty))?,)*
-	}
+        #[$attr:meta]
+        $vis:vis enum $id:ident {
+            $( $variant:ident$(($ty:ty))?, )*
+        }
     } => {
-	#[$attr]
-	$vis enum $id {
-	    $($variant$(($ty))?,)*
-	}
+        #[$attr]
+        $vis enum $id {
+            $( $variant$(($ty))?, )*
+        }
 
-	impl $id {
-	    pub fn type_(&self) -> &'static str {
-		match self {
-		    $(Self::$variant(_) => stringify!($variant),)*
-		}
-	    }
-	}
+        impl $id {
+            pub fn type_(&self) -> &'static str {
+                match self {
+                    $( Self::$variant(_) => stringify!($variant), )*
+                }
+            }
+        }
 
-	$(
-	    $(
-		impl From<$ty> for $id {
-		    fn from(value: $ty) -> Self {
-			Self::$variant(value)
-		    }
-		}
-	    )?
-	)*
+        $(
+            $(
+                impl From<$ty> for $id {
+                    fn from(value: $ty) -> Self {
+                        Self::$variant(value)
+                    }
+                }
+            )?
+        )*
     };
 }
 

--- a/core/src/graph/string/faker.rs
+++ b/core/src/graph/string/faker.rs
@@ -43,22 +43,21 @@ macro_rules! fake_map_entry {
     };
     (with_locales; $name:ident, $rng:ident, $args:ident, $map:ident, $faker:ident; $($locale:ident),*) => {
         fn $name($rng: &mut dyn RngCore, $args: &FakerArgs) -> String {
-            match $args .locales.get($rng.gen_range(0..$args .locales.len().max(1))).unwrap_or(&Locale::EN) {
+            match $args.locales.get($rng.gen_range(0..$args.locales.len().max(1))).unwrap_or(&Locale::EN) {
                 $(Locale::$locale => $faker(locales::$locale).fake_with_rng($rng)),*
             }
         }
-        $map .insert(stringify!($name), $name as _);
+        $map.insert(stringify!($name), $name as _);
     };
     ($name:ident, $rng:ident, $args:ident, $map:ident, $e:expr) => {
         fn $name($rng: &mut dyn RngCore, $args: &FakerArgs) -> String {
             $e
         }
-        $map .insert(stringify!($name), $name as _);
+        $map.insert(stringify!($name), $name as _);
     };
 }
 
 lazy_static! {
-
     static ref FAKE_MAP: HashMap<&'static str, FakerFunction> = {
         let mut m = HashMap::new();
         // Lorem

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -15,7 +15,7 @@ macro_rules! derive_generator {
         return $return:ty,
         $vis:vis enum $id:ident {
             $(
-            $variant:ident($inner:ty$(,)?)$(,)?
+                $variant:ident($inner:ty$(,)?)$(,)?
             )*
         }
     } => {
@@ -31,7 +31,7 @@ macro_rules! derive_generator {
             fn next<R: Rng>(&mut self, rng: &mut R) -> ::synth_gen::prelude::GeneratorState<Self::Yield, Self::Return> {
                 match self {
                     $(
-                    Self::$variant(inner) => inner.next(rng),
+                        Self::$variant(inner) => inner.next(rng),
                     )*
                 }
             }

--- a/core/src/schema/content/date_time.rs
+++ b/core/src/schema/content/date_time.rs
@@ -343,39 +343,39 @@ pub mod tests {
     use crate::compile::NamespaceCompiler;
     use chrono::naive::{MAX_DATE, MIN_DATE};
 
-    macro_rules! date_time_bounds_test_ok (
+    macro_rules! date_time_bounds_test_ok {
         ($begin:expr, $end:expr) => {
             let unspecified_begin_end = DateTimeContent {
-            format: "yyyy-MM-dd".to_string(),
-            type_: ChronoValueType::NaiveDate,
-            begin: $begin,
-            end: $end
+                format: "yyyy-MM-dd".to_string(),
+                type_: ChronoValueType::NaiveDate,
+                begin: $begin,
+                end: $end,
+            };
+
+            let content = Content::DateTime(unspecified_begin_end);
+
+            let compiler = NamespaceCompiler::new_flat(&content);
+
+            assert!(compiler.compile().is_ok());
         };
+    }
 
-        let content = Content::DateTime(unspecified_begin_end);
-
-        let compiler = NamespaceCompiler::new_flat(&content);
-
-        assert!(compiler.compile().is_ok());
-        }
-    );
-
-    macro_rules! date_time_bounds_test_err (
+    macro_rules! date_time_bounds_test_err {
         ($begin:expr, $end:expr) => {
             let unspecified_begin_end = DateTimeContent {
-            format: "yyyy-MM-dd".to_string(),
-            type_: ChronoValueType::NaiveDate,
-            begin: $begin,
-            end: $end
+                format: "yyyy-MM-dd".to_string(),
+                type_: ChronoValueType::NaiveDate,
+                begin: $begin,
+                end: $end,
+            };
+
+            let content = Content::DateTime(unspecified_begin_end);
+
+            let compiler = NamespaceCompiler::new_flat(&content);
+
+            assert!(compiler.compile().is_err());
         };
-
-        let content = Content::DateTime(unspecified_begin_end);
-
-        let compiler = NamespaceCompiler::new_flat(&content);
-
-        assert!(compiler.compile().is_err());
-        }
-    );
+    }
 
     #[test]
     fn date_time_compile() {

--- a/core/src/schema/content/mod.rs
+++ b/core/src/schema/content/mod.rs
@@ -149,7 +149,7 @@ macro_rules! content {
         impl<'de> Deserialize<'de> for Content {
             fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
             where
-            D: Deserializer<'de>,
+                D: Deserializer<'de>,
             {
                 #[derive(Deserialize)]
                 #[serde(rename_all = "snake_case")]
@@ -178,7 +178,7 @@ macro_rules! content {
 
                     fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
                     where
-                    A: serde::de::MapAccess<'de>
+                        A: serde::de::MapAccess<'de>
                     {
                         use serde::de::IntoDeserializer;
                         let mut out = HashMap::<String, serde_json::Value>::new();
@@ -188,37 +188,39 @@ macro_rules! content {
                         }
                         let __ContentWithLabels { labels, content } = __ContentWithLabels::deserialize(out.into_deserializer()).map_err(A::Error::custom)?;
                         match content {
-                            $(__Content::$name(inner) => {
-                                let inner_as_content = Content::$name(inner);
-                                labels.try_wrap(inner_as_content)
-                            },)+
+                            $(
+                                __Content::$name(inner) => {
+                                    let inner_as_content = Content::$name(inner);
+                                    labels.try_wrap(inner_as_content)
+                                },
+                            )+
                         }
                     }
 
                     fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
                     where
-                    E: serde::de::Error
+                        E: serde::de::Error
                     {
                         Ok(Content::Number(number_content::U64::from(v).into()))
                     }
 
                     fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
                     where
-                    E: serde::de::Error
+                        E: serde::de::Error
                     {
                         Ok(Content::Number(number_content::I64::from(v).into()))
                     }
 
                     fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
                     where
-                    E: serde::de::Error
+                        E: serde::de::Error
                     {
                         Ok(Content::Number(number_content::F64::from(v).into()))
                     }
 
                     fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
                     where
-                    E: serde::de::Error
+                        E: serde::de::Error
                     {
                         if let Some(s) = v.strip_prefix("@") {
                             let ref_ = FieldRef::deserialize(s.into_deserializer())?;
@@ -754,11 +756,11 @@ pub mod tests {
     }
 
     macro_rules! assert_idempotent {
-	($($inner:tt)*) => {
-	    let in_: DateTimeContent = serde_json::from_value(json!($($inner)*)).unwrap();
-	    let out = serde_json::to_string(&in_).unwrap();
-	    assert_eq!(serde_json::from_str::<'_, DateTimeContent>(&out).unwrap(), in_);
-	}
+        ($($inner:tt)*) => {
+            let in_: DateTimeContent = serde_json::from_value(json!($($inner)*)).unwrap();
+            let out = serde_json::to_string(&in_).unwrap();
+            assert_eq!(serde_json::from_str::<'_, DateTimeContent>(&out).unwrap(), in_);
+        }
     }
 
     #[test]

--- a/core/src/schema/inference/mod.rs
+++ b/core/src/schema/inference/mod.rs
@@ -380,7 +380,9 @@ pub mod tests {
     use std::str::FromStr;
 
     macro_rules! as_array {
-	[$($ident:ident)*] => { Value::from(vec![$($ident.clone())*]) }
+        [$($ident:ident)*] => {
+            Value::from(vec![$($ident.clone())*])
+        }
     }
 
     #[test]

--- a/gen/src/de.rs
+++ b/gen/src/de.rs
@@ -34,7 +34,7 @@ where
 impl<'de, I> TokenIterator<'de> for I where I: Iterator<Item = &'de Token> {}
 
 macro_rules! deserialize_number {
-    ($($type_:ident,)*) => {$(deserialize_number_helper!($type_);)*};
+    ($($type_:ident,)*) => { $(deserialize_number_helper!($type_);)* };
 }
 
 macro_rules! deserialize_number_helper {
@@ -69,32 +69,32 @@ macro_rules! deserialize_number_impl {
 
 macro_rules! deserialize_value {
     ($($type_:ty => $de:ident $visit:ident,)*) => {
-	$(deserialize_value!($type_ => $de $visit);)*
+        $(deserialize_value!($type_ => $de $visit);)*
     };
     ($type_:ty => $de:ident $visit:ident) => {
         fn $de<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where
             V: serde::de::Visitor<'de>,
         {
-	    self.0
-		.clone_next_or_bail()?
-		.try_into()
-		.and_then(|p: Primitive| visitor.$visit(p.try_into()?))
+            self.0
+                .clone_next_or_bail()?
+                .try_into()
+                .and_then(|p: Primitive| visitor.$visit(p.try_into()?))
         }
     };
 }
 
 macro_rules! deserialize_redirect {
     ($($de:ident -> $rde:ident,)*) => {
-	$(deserialize_redirect!($de -> $rde);)*
+        $(deserialize_redirect!($de -> $rde);)*
     };
     ($de:ident -> $rde:ident) => {
-	fn $de<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
+        fn $de<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
             V: serde::de::Visitor<'de>,
-	{
-	    self.$rde(visitor)
-	}
+        {
+            self.$rde(visitor)
+        }
     };
 }
 
@@ -247,9 +247,9 @@ where
     }
 
     deserialize_value!(
-    bool => deserialize_bool visit_bool,
-    char => deserialize_char visit_char,
-    Vec<u8> => deserialize_byte_buf visit_byte_buf,
+        bool => deserialize_bool visit_bool,
+        char => deserialize_char visit_char,
+        Vec<u8> => deserialize_byte_buf visit_byte_buf,
     );
 
     deserialize_number!(
@@ -268,8 +268,8 @@ where
     );
 
     deserialize_redirect!(
-    deserialize_str -> deserialize_string,
-    deserialize_bytes -> deserialize_byte_buf,
+        deserialize_str -> deserialize_string,
+        deserialize_bytes -> deserialize_byte_buf,
     );
 
     fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>

--- a/gen/src/lib.rs
+++ b/gen/src/lib.rs
@@ -16,14 +16,14 @@ use std::{fmt::Debug, marker::PhantomData};
 #[allow(unused_macros)]
 macro_rules! curry_rng {
     ($($id:ident -> $ret:ty,)*) => {
-	$(curry_rng!($id -> $ret);)*
+        $(curry_rng!($id -> $ret);)*
     };
     ($id:ident -> $ret:ty) => {
-	/// Run the inner generator's `$id` function on the driver's
-	/// [`Rng`](crate::Rng).
-	pub fn $id(&mut self) -> $ret {
-	    self.generator.$id(self.rng)
-	}
+        /// Run the inner generator's `$id` function on the driver's
+        /// [`Rng`](crate::Rng).
+        pub fn $id(&mut self) -> $ret {
+            self.generator.$id(self.rng)
+        }
     };
 }
 

--- a/gen/src/value.rs
+++ b/gen/src/value.rs
@@ -19,169 +19,169 @@ pub type OrderedFloat64 = OrderedFloat<f64>;
 
 macro_rules! generate_enum {
     {
-	$(#[$attr:meta])*
-	$vis:vis enum $id:ident {
-	    $(
-		$(#[$variant_attr:meta])*
-		$variant:ident($type_:ty),
-	    )*
-	}
+        $(#[$attr:meta])*
+        $vis:vis enum $id:ident {
+            $(
+                $(#[$variant_attr:meta])*
+                $variant:ident($type_:ty),
+            )*
+        }
     } => {
-	$(#[$attr])*
-	$vis enum $id {
-	    $(
-		$(#[$variant_attr])*
-		$variant($type_),
-	    )*
-	}
+        $(#[$attr])*
+        $vis enum $id {
+            $(
+                $(#[$variant_attr])*
+                $variant($type_),
+            )*
+        }
 
-	impl std::fmt::Display for $id {
-	    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		match self {
-		    $(
-			Self::$variant(inner) => write!(f, "{:?}", inner),
-		    )*
-		}
-	    }
-	}
+        impl std::fmt::Display for $id {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                match self {
+                    $(
+                        Self::$variant(inner) => write!(f, "{:?}", inner),
+                    )*
+                }
+            }
+        }
 
-	impl std::fmt::Debug for $id {
-	    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		match self {
-		    $(
-			Self::$variant(inner) => write!(f, "{}({:?})", stringify!($type_), inner),
-		    )*
-		}
-	    }
-	}
+        impl std::fmt::Debug for $id {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                match self {
+                    $(
+                        Self::$variant(inner) => write!(f, "{}({:?})", stringify!($type_), inner),
+                    )*
+                }
+            }
+        }
 
-	$(
-	    impl From<$type_> for $id {
-		fn from(value: $type_) -> Self {
-		    Self::$variant(value)
-		}
-	    }
-	)*
+        $(
+            impl From<$type_> for $id {
+                fn from(value: $type_) -> Self {
+                    Self::$variant(value)
+                }
+            }
+        )*
 
-	$(
-	    impl TryFrom<$id> for $type_ {
-		type Error = Error;
-		fn try_from(value: $id) -> Result<$type_, <Self as TryFrom<$id>>::Error> {
-		    match value {
-			$id::$variant(value) => Ok(value),
-			otherwise => Err(Error::r#type(stringify!($variant), otherwise))
-		    }
-		}
-	    }
-	)*
+        $(
+            impl TryFrom<$id> for $type_ {
+                type Error = Error;
+                fn try_from(value: $id) -> Result<$type_, <Self as TryFrom<$id>>::Error> {
+                    match value {
+                        $id::$variant(value) => Ok(value),
+                        otherwise => Err(Error::r#type(stringify!($variant), otherwise))
+                    }
+                }
+            }
+        )*
     };
 }
 
 macro_rules! is_variant {
     {
-	#[$name:expr]
-	$item:item
+        #[$name:expr]
+        $item:item
     } => {
-	#[doc = "Check if the token is an instance of `"]
-	#[doc = $name]
-	#[doc = "`."]
-	$item
+        #[doc = "Check if the token is an instance of `"]
+        #[doc = $name]
+        #[doc = "`."]
+        $item
     }
 }
 
 macro_rules! to_variant {
     {
-	#[$name:expr]
-	$item:item
+        #[$name:expr]
+        $item:item
     } => {
-	#[doc = "Consume the token and extract out the arguments for `"]
-	#[doc = $name]
-	#[doc = "`."]
-	/// # Errors
-	/// If `self` is not an instance of a `
-	#[doc = $name]
-	#[doc = "` "]
-	/// token, a custom error of type `S::Error` is returned.
-	$item
+        #[doc = "Consume the token and extract out the arguments for `"]
+        #[doc = $name]
+        #[doc = "`."]
+        /// # Errors
+        /// If `self` is not an instance of a `
+        #[doc = $name]
+        #[doc = "` "]
+        /// token, a custom error of type `S::Error` is returned.
+        $item
     }
 }
 
 macro_rules! generate_special_enum {
     {
-	$(#[$attr:meta])*
-	$vis:vis enum $id:ident {
-	    $(
-		$(#[$variant_attr:meta])*
-		$variant:ident$(($($arg:ty as $var:ident,)*))? -> $is:ident $to:ident,
-	    )*
-	}
+        $(#[$attr:meta])*
+        $vis:vis enum $id:ident {
+            $(
+                $(#[$variant_attr:meta])*
+                $variant:ident$(($($arg:ty as $var:ident,)*))? -> $is:ident $to:ident,
+            )*
+        }
     } => {
-	$(#[$attr])*
-	$vis enum $id {
-	    $(
-		$(#[$variant_attr])*
-		$variant$(($($arg,)*))*,
-	    )*
-	}
+        $(#[$attr])*
+        $vis enum $id {
+            $(
+                $(#[$variant_attr])*
+                $variant$(($($arg,)*))*,
+            )*
+        }
 
-	impl std::fmt::Display for $id {
-	    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		match self {
-		    $(
-			Self::$variant$(($(drop!($arg),)*))? =>
-			    write!(f, "{}", stringify!($variant)),
-		    )*
-		}
-	    }
-	}
+        impl std::fmt::Display for $id {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                match self {
+                    $(
+                        Self::$variant$(($(drop!($arg),)*))? =>
+                            write!(f, "{}", stringify!($variant)),
+                    )*
+                }
+            }
+        }
 
-	impl Token {
-	    $(
-		is_variant! {
-		    #[stringify!($variant)]
-		    pub fn $is(&self) -> bool {
-			match self {
-			    Self::$id($id::$variant$(($(drop!($arg),)*))?) => true,
-			    _ => false
-			}
-		    }
-		}
+        impl Token {
+            $(
+                is_variant! {
+                    #[stringify!($variant)]
+                    pub fn $is(&self) -> bool {
+                        match self {
+                            Self::$id($id::$variant$(($(drop!($arg),)*))?) => true,
+                            _ => false
+                        }
+                    }
+                }
 
-		to_variant! {
-		    #[stringify!($variant)]
-		    pub fn $to<E: serde::ser::Error>(self) -> Result<($($($arg,)*)?), E> {
-			match self {
-			    Token::$id($id::$variant$(($($var,)*))?) => Ok(($($($var,)*)*)),
-			    otherwise => {
-				let err = format!(
-				    "unexpected: wanted {}, got {:?}",
-				    stringify!($variant),
-				    otherwise
-				);
-				Err(E::custom(err))
-			    }
-			}
-		    }
-		}
-	    )*
-	}
+                to_variant! {
+                    #[stringify!($variant)]
+                    pub fn $to<E: serde::ser::Error>(self) -> Result<($($($arg,)*)?), E> {
+                        match self {
+                            Token::$id($id::$variant$(($($var,)*))?) => Ok(($($($var,)*)*)),
+                            otherwise => {
+                                let err = format!(
+                                    "unexpected: wanted {}, got {:?}",
+                                    stringify!($variant),
+                                    otherwise
+                                );
+                                Err(E::custom(err))
+                            }
+                        }
+                    }
+                }
+            )*
+        }
 
-	/// **DEPRECATED** Used by the
-	/// [`bynar::de::Deserializer`](crate::de::Deserializer).
-	#[allow(missing_docs)]
-	pub trait SpecialTokenExt: Generator<Yield = Token> {
-	    $(
-		#[inline]
-		fn $to<R: Rng>(&mut self, rng: &mut R) -> Result<(), Error> {
-		    match self.next(rng).into_yielded()?.try_into()? {
-			$id::$variant$(($(drop!($arg),)*))? => Ok(()),
-			otherwise => Err(Error::r#type(stringify!($variant), otherwise))
-		    }
-		}
-	    )*
-	}
+        /// **DEPRECATED** Used by the
+        /// [`bynar::de::Deserializer`](crate::de::Deserializer).
+        #[allow(missing_docs)]
+        pub trait SpecialTokenExt: Generator<Yield = Token> {
+            $(
+                #[inline]
+                fn $to<R: Rng>(&mut self, rng: &mut R) -> Result<(), Error> {
+                    match self.next(rng).into_yielded()?.try_into()? {
+                        $id::$variant$(($(drop!($arg),)*))? => Ok(()),
+                        otherwise => Err(Error::r#type(stringify!($variant), otherwise))
+                    }
+                }
+            )*
+        }
 
-	impl<G> SpecialTokenExt for G where G: Generator<Yield = Token> {}
+        impl<G> SpecialTokenExt for G where G: Generator<Yield = Token> {}
     };
 }
 
@@ -191,35 +191,35 @@ macro_rules! drop {
 
 macro_rules! into_composite {
     {
-	$name:expr,
+        $name:expr,
         $(#[$attr:meta])*,
         $item:item
     } => {
-	/// Make `self` a composite generator of type `
-	#[doc = $name]
-	#[doc = "`. See"]
-	$(#[$attr])*
-	#[doc = " for documentation on the arguments."]
-	$item
+        /// Make `self` a composite generator of type `
+        #[doc = $name]
+        #[doc = "`. See"]
+        $(#[$attr])*
+        #[doc = " for documentation on the arguments."]
+        $item
     }
 }
 
 macro_rules! data_model_variant_impl_ext {
     {
-	$(
-	    $(#[$attr:meta])*
-	    $as:ident($($arg:ident: $ty:ty$(,)?)*) -> $id:ident$(,)?
-	)*
+        $(
+            $(#[$attr:meta])*
+            $as:ident($($arg:ident: $ty:ty$(,)?)*) -> $id:ident$(,)?
+        )*
     } => {
-	$(
-	    into_composite! {
-		stringify!($id),
-		$(#[$attr])*,
-		fn $as(self, $($arg: $ty,)*) -> $id<Self> {
-		    $id::new(self, $($arg,)*)
-		}
-	    }
-	)*
+        $(
+            into_composite! {
+                stringify!($id),
+                $(#[$attr])*,
+                fn $as(self, $($arg: $ty,)*) -> $id<Self> {
+                    $id::new(self, $($arg,)*)
+                }
+            }
+        )*
     }
 }
 
@@ -333,20 +333,20 @@ generate_special_enum!(
     #[allow(missing_docs)]
     #[derive(Clone, Debug, PartialEq, Eq, Hash)]
     pub enum Special {
-    BeginMap(Option<usize> as len,) -> is_begin_map begin_map,
-    EndMap -> is_end_map end_map,
-    BeginStruct(&'static str as s, usize as n,) -> is_begin_struct begin_struct,
-    EndStruct -> is_end_struct end_struct,
-    BeginField(&'static str as s,) -> is_begin_field begin_field,
-    BeginTuple(usize as n,) -> is_begin_tuple begin_tuple,
-    EndTuple -> is_end_tuple end_tuple,
-    BeginSeq(Option<usize> as n,) -> is_begin_seq begin_seq,
-    EndSeq -> is_end_seq end_seq,
-    BeginSome -> is_begin_some begin_some,
-    None -> is_none none,
-    UnitStruct(&'static str as s,) -> is_unit_struct unit_struct,
-    UnitVariant(&'static str as n, u32 as i, &'static str as s,) -> is_unit_variant unit_variant,
-    Error(Error as error,) -> is_error error,
+        BeginMap(Option<usize> as len,) -> is_begin_map begin_map,
+        EndMap -> is_end_map end_map,
+        BeginStruct(&'static str as s, usize as n,) -> is_begin_struct begin_struct,
+        EndStruct -> is_end_struct end_struct,
+        BeginField(&'static str as s,) -> is_begin_field begin_field,
+        BeginTuple(usize as n,) -> is_begin_tuple begin_tuple,
+        EndTuple -> is_end_tuple end_tuple,
+        BeginSeq(Option<usize> as n,) -> is_begin_seq begin_seq,
+        EndSeq -> is_end_seq end_seq,
+        BeginSome -> is_begin_some begin_some,
+        None -> is_none none,
+        UnitStruct(&'static str as s,) -> is_unit_struct unit_struct,
+        UnitVariant(&'static str as n, u32 as i, &'static str as s,) -> is_unit_variant unit_variant,
+        Error(Error as error,) -> is_error error,
     }
 );
 
@@ -382,16 +382,16 @@ impl<G> TokenGenerator for G where G: Generator<Yield = Token> {}
 /// data types from [`TokenGenerator`](crate::value::TokenGenerator).
 pub trait TokenGeneratorExt: TokenGenerator + Sized {
     data_model_variant_impl_ext! {
-    /// [`serialize_field`](serde::ser::SerializeStruct::serialize_field)
-    into_struct_field(name: &'static str) -> StructField,
-    /// [`serialize_struct`](serde::ser::Serializer::serialize_struct)
-    into_struct(name: &'static str, len: usize) -> Struct,
-    /// [`serialize_seq`](serde::ser::Serializer::serialize_seq)
-    into_seq(len: Option<usize>) -> Seq,
-    /// [`serialize_tuple`](serde::ser::Serializer::serialize_tuple)
-    into_tuple(len: usize) -> Tuple,
-    /// [`serialize_map`](serde::ser::Serializer::serialize_map)
-    into_map(len: Option<usize>) -> Map,
+        /// [`serialize_field`](serde::ser::SerializeStruct::serialize_field)
+        into_struct_field(name: &'static str) -> StructField,
+        /// [`serialize_struct`](serde::ser::Serializer::serialize_struct)
+        into_struct(name: &'static str, len: usize) -> Struct,
+        /// [`serialize_seq`](serde::ser::Serializer::serialize_seq)
+        into_seq(len: Option<usize>) -> Seq,
+        /// [`serialize_tuple`](serde::ser::Serializer::serialize_tuple)
+        into_tuple(len: usize) -> Tuple,
+        /// [`serialize_map`](serde::ser::Serializer::serialize_map)
+        into_map(len: Option<usize>) -> Map,
     }
 
     fn with_key<K: TokenGenerator>(self, key: K) -> Concatenate<K, Self> {
@@ -435,30 +435,30 @@ impl IntoToken for Token {
 
 macro_rules! impl_into_token {
     {
-	$(
-	    $track:ident: $($ty:ty$(,)?)+ => $fst:ty $(=> $inter:ty)* $(,)?
-	)*
+        $(
+            $track:ident: $($ty:ty$(,)?)+ => $fst:ty $(=> $inter:ty)* $(,)?
+        )*
     } => {
-	$(
-	    #[inline]
-	    fn $track<I>(x: I) -> Token
-	    where
-		$fst: From<I>
-	    {
-		let out: $fst = x.into();
-		$(let out: $inter = out.into();)*
-		out
-	    }
+        $(
+            #[inline]
+            fn $track<I>(x: I) -> Token
+            where
+                $fst: From<I>
+            {
+                let out: $fst = x.into();
+                $(let out: $inter = out.into();)*
+                out
+            }
 
-	    $(
-		impl IntoToken for $ty {
-		    #[inline]
-		    fn into_token(self) -> Token {
-			$track(self)
-		    }
-		}
-	    )+
-	)*
+            $(
+                impl IntoToken for $ty {
+                    #[inline]
+                    fn into_token(self) -> Token {
+                        $track(self)
+                    }
+                }
+            )+
+        )*
     }
 }
 
@@ -530,44 +530,44 @@ where
 
 macro_rules! data_model_variant {
     {
-	$name:expr,
-	$serde:expr,
-	$id:ident<G>($($arg:ident: $ty:ty$(,)?)*) -> $inner:ty = $cl:expr
+        $name:expr,
+        $serde:expr,
+        $id:ident<G>($($arg:ident: $ty:ty$(,)?)*) -> $inner:ty = $cl:expr
     } => {
-	#[doc = $name]
-    pub struct $id<G>
-	where
-	    G: Generator<Yield = Token>
-	{
-	    pub inner: $inner
-	}
+        #[doc = $name]
+        pub struct $id<G>
+        where
+            G: Generator<Yield = Token>
+        {
+            pub inner: $inner
+        }
 
-	impl<G> $id<G>
-	where
-	    G: Generator<Yield = Token>,
-	{
-	    /// Create a new instance from a generator `G`. See
-	    #[doc = $serde]
-	    /// for documentation on the additional arguments.
-	    pub fn new(generator: G, $($arg: $ty,)*) -> Self {
-		Self {
-		    inner: ($cl)(generator)
-		}
-	    }
-	}
+        impl<G> $id<G>
+        where
+            G: Generator<Yield = Token>,
+        {
+            /// Create a new instance from a generator `G`. See
+            #[doc = $serde]
+            /// for documentation on the additional arguments.
+            pub fn new(generator: G, $($arg: $ty,)*) -> Self {
+                Self {
+                    inner: ($cl)(generator)
+                }
+            }
+        }
 
-	impl<G> Generator for $id<G>
-	where
-	    G: Generator<Yield = Token>,
-	{
-	    type Yield = G::Yield;
+        impl<G> Generator for $id<G>
+        where
+            G: Generator<Yield = Token>,
+        {
+            type Yield = G::Yield;
 
-	    type Return = G::Return;
+            type Return = G::Return;
 
-	    fn next<R: Rng>(&mut self, rng: &mut R) -> GeneratorState<Self::Yield, Self::Return> {
-		self.inner.next(rng)
-	    }
-	}
+            fn next<R: Rng>(&mut self, rng: &mut R) -> GeneratorState<Self::Yield, Self::Return> {
+                self.inner.next(rng)
+            }
+        }
     }
 }
 
@@ -646,26 +646,26 @@ pub mod tests {
     }
 
     macro_rules! test_primitive_values {
-	{
-	    $(
-		$id:ident<$ty:ty>$(,)?
-	    )*
-	} => {
-	    $(
-		#[test]
-		fn $id() {
-		    let mut rng = rand::thread_rng();
-		    let mut seed = Random::new::<$ty>()
-			.once()
-			.into_token()
-			.aggregate();
-		    let next = seed.next(&mut rng).into_yielded().unwrap();
-		    let as_ser = OwnedSerializable::new(next);
-		    let as_str = serde_json::to_string(&as_ser).unwrap();
-		    let _as_num: $ty = serde_json::from_str(&as_str).unwrap();
-		}
-	    )*
-	}
+        {
+            $(
+                $id:ident<$ty:ty>$(,)?
+            )*
+        } => {
+            $(
+                #[test]
+                fn $id() {
+                    let mut rng = rand::thread_rng();
+                    let mut seed = Random::new::<$ty>()
+                        .once()
+                        .into_token()
+                        .aggregate();
+                    let next = seed.next(&mut rng).into_yielded().unwrap();
+                    let as_ser = OwnedSerializable::new(next);
+                    let as_str = serde_json::to_string(&as_ser).unwrap();
+                    let _as_num: $ty = serde_json::from_str(&as_str).unwrap();
+                }
+            )*
+        }
     }
 
     test_primitive_values!(

--- a/synth/src/cli/config.rs
+++ b/synth/src/cli/config.rs
@@ -18,22 +18,22 @@ macro_rules! config {
         #[derive(Serialize, Deserialize, Default)]
         struct Config {
             $(
-            #[serde(skip_serializing_if = "Option::is_none")]
-            $val_name: Option<$ty>,
+                #[serde(skip_serializing_if = "Option::is_none")]
+                $val_name: Option<$ty>,
             )*
         }
 
         $(
-        #[allow(dead_code)]
-        pub fn $setter($val_name: $ty) {
-            let mut config = CONFIG.lock().unwrap();
-            config.$val_name = Some($val_name);
-            config.save();
-        }
-        #[allow(dead_code)]
-        pub fn $getter() -> Option<$ty> {
-            CONFIG.lock().unwrap().$val_name.clone()
-        }
+            #[allow(dead_code)]
+            pub fn $setter($val_name: $ty) {
+                let mut config = CONFIG.lock().unwrap();
+                config.$val_name = Some($val_name);
+                config.save();
+            }
+            #[allow(dead_code)]
+            pub fn $getter() -> Option<$ty> {
+                CONFIG.lock().unwrap().$val_name.clone()
+            }
         )*
 
     }

--- a/synth/src/error.rs
+++ b/synth/src/error.rs
@@ -4,16 +4,16 @@ pub use synth_core::error::*;
 
 macro_rules! failed {
     (target: $target:ident, $lit: literal$(, $arg:expr)*) => {
-	failed!(target: $target, BadRequest => $lit$(, $arg)*)
+        failed!(target: $target, BadRequest => $lit$(, $arg)*)
     };
     (target: $target:ident, $variant:ident => $lit:literal$(, $arg:expr)*) => {
-	anyhow::Error::from(
-	    crate::error::Error::new(
-		crate::error::ErrorKind::$variant,
-		format!($lit$(, $arg)*),
-		crate::error::Target::$target
-	    )
-	)
+        anyhow::Error::from(
+            crate::error::Error::new(
+                crate::error::ErrorKind::$variant,
+                format!($lit$(, $arg)*),
+                crate::error::Target::$target
+            )
+        )
     };
 }
 


### PR DESCRIPTION
Apparently, `rustfmt` [cannot format declarative macros](https://github.com/rust-lang/rustfmt/issues/8#issue-60295777), so this is my attempt to do that manually.