### PR TITLE
feat: add basic string slicing via the `sliced` generator

### DIFF
--- a/core/src/graph/mod.rs
+++ b/core/src/graph/mod.rs
@@ -749,6 +749,22 @@ pub mod tests {
                     "a_large_number": {
                         "type": "number",
                         "range": {}
+                    },
+                    "constant_id": "42",
+                    "created_at_year": {
+                        "type": "string",
+                        "sliced": {
+                            "content": {
+                                "type": "string",
+                                "format": {
+                                    "format": "{date} ",
+                                    "arguments": {
+                                        "date": "@users.content.created_at_date"
+                                    }
+                                }
+                            },
+                            "slice": "0:4"
+                        }
                     }
                 }
             },
@@ -839,6 +855,8 @@ pub mod tests {
             created_at_time: String,
             last_login_at: String,
             num_logins_again: u64,
+            constant_id: String,
+            created_at_year: String,
         }
 
         for _ in 0..100 {
@@ -857,6 +875,8 @@ pub mod tests {
                 assert!(user.bank_country == "GB" || user.bank_country == "ES");
                 assert!(user.id >= 100);
                 assert!(user.username.len() <= 5);
+                assert_eq!(user.constant_id, "42");
+                assert_eq!(user.created_at_year, user.created_at_date[0..4]);
 
                 all_users.insert(user.username.as_str());
 

--- a/core/src/graph/string/constant.rs
+++ b/core/src/graph/string/constant.rs
@@ -1,0 +1,13 @@
+use crate::graph::prelude::*;
+
+pub struct Constant(pub String);
+
+impl Generator for Constant {
+    type Yield = String;
+    type Return = Result<String, Error>;
+
+    fn next<R: Rng>(&mut self, _rng: &mut R) -> GeneratorState<Self::Yield, Self::Return> {
+        let s = self.0.clone();
+        GeneratorState::Complete(Ok(s))
+    }
+}

--- a/core/src/graph/string/constant.rs
+++ b/core/src/graph/string/constant.rs
@@ -4,10 +4,10 @@ pub struct Constant(pub String);
 
 impl Generator for Constant {
     type Yield = String;
-    type Return = Result<String, Error>;
+    type Return = Never;
 
     fn next<R: Rng>(&mut self, _rng: &mut R) -> GeneratorState<Self::Yield, Self::Return> {
         let s = self.0.clone();
-        GeneratorState::Complete(Ok(s))
+        GeneratorState::Yielded(s)
     }
 }

--- a/core/src/graph/string/mod.rs
+++ b/core/src/graph/string/mod.rs
@@ -30,7 +30,7 @@ derive_generator! {
         Format(Format),
         Truncated(Truncated),
         Sliced(Sliced),
-        Constant(Constant)
+        Constant(OnceInfallible<Constant>),
     }
 }
 
@@ -71,14 +71,14 @@ impl From<Truncated> for RandomString {
 }
 
 impl From<Sliced> for RandomString {
-    fn from(trunc: Sliced) -> Self {
-        Self::Sliced(trunc)
+    fn from(sliced: Sliced) -> Self {
+        Self::Sliced(sliced)
     }
 }
 
 impl From<Constant> for RandomString {
-    fn from(trunc: Constant) -> Self {
-        Self::Constant(trunc)
+    fn from(const_: Constant) -> Self {
+        Self::Constant(const_.infallible().try_once())
     }
 }
 

--- a/core/src/graph/string/mod.rs
+++ b/core/src/graph/string/mod.rs
@@ -2,16 +2,20 @@ use super::prelude::*;
 
 use rand_regex::Regex as RandRegex;
 
+pub mod constant;
 pub mod faker;
 pub mod format;
 pub mod serialized;
+pub mod sliced;
 pub mod truncated;
 pub mod uuid;
 
 pub use self::uuid::UuidGen;
+pub use constant::Constant;
 pub use faker::{FakerArgs, Locale, RandFaker};
 pub use format::{Format, FormatArgs};
 pub use serialized::Serialized;
+pub use sliced::Sliced;
 pub use truncated::Truncated;
 
 derive_generator! {
@@ -24,7 +28,9 @@ derive_generator! {
         Categorical(OnceInfallible<Random<String, Categorical<String>>>)
         Uuid(OnceInfallible<UuidGen>),
         Format(Format),
-        Truncated(Truncated)
+        Truncated(Truncated),
+        Sliced(Sliced),
+        Constant(Constant)
     }
 }
 
@@ -61,6 +67,18 @@ impl From<UuidGen> for RandomString {
 impl From<Truncated> for RandomString {
     fn from(trunc: Truncated) -> Self {
         Self::Truncated(trunc)
+    }
+}
+
+impl From<Sliced> for RandomString {
+    fn from(trunc: Sliced) -> Self {
+        Self::Sliced(trunc)
+    }
+}
+
+impl From<Constant> for RandomString {
+    fn from(trunc: Constant) -> Self {
+        Self::Constant(trunc)
     }
 }
 

--- a/core/src/graph/string/sliced.rs
+++ b/core/src/graph/string/sliced.rs
@@ -1,0 +1,43 @@
+use crate::graph::prelude::*;
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+pub fn slice(what: String, len: String) -> String {
+    // what.truncate(len as usize);
+    if let Some((l, r)) = len.split_once(':') {
+        let li = l.parse::<usize>().unwrap();
+        let ri = if r.is_empty() {
+            what.len()
+        } else {
+            r.parse::<usize>().unwrap()
+        };
+
+        what[li..ri].to_string()
+    } else {
+        what
+    }
+}
+
+type Slicer = MapOk<Rc<RefCell<StringGenerator>>, Box<dyn Fn(String) -> String>, String>;
+
+type SlicedInner = TryYield<AndThenTry<StringGenerator, Box<dyn Fn(String) -> Slicer>, Slicer>>;
+
+derive_generator! {
+    yield String,
+    return Result<String, Error>,
+    pub struct Sliced(SlicedInner);
+}
+
+impl Sliced {
+    pub(crate) fn new(content: StringGenerator, slices: StringGenerator) -> Self {
+        let length = Rc::new(RefCell::new(slices));
+        let slicer = Box::new(move |s: String| {
+            let do_slice =
+                Box::new(move |len| slice(s.clone(), len)) as Box<dyn Fn(String) -> String>;
+            length.clone().map_ok(do_slice)
+        }) as Box<dyn Fn(String) -> Slicer>;
+        let out = content.and_then_try(slicer).try_yield();
+        Self(out)
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,11 +1,4 @@
-#![feature(
-    format_args_capture,
-    async_closure,
-    map_first_last,
-    box_patterns,
-    error_iter,
-    try_blocks
-)]
+#![feature(async_closure, map_first_last, box_patterns, error_iter, try_blocks)]
 #![allow(type_alias_bounds)]
 
 #[macro_export]

--- a/core/src/schema/content/mod.rs
+++ b/core/src/schema/content/mod.rs
@@ -26,7 +26,8 @@ pub use number::{number_content, NumberContent, NumberContentKind, NumberKindExt
 
 mod string;
 pub use string::{
-    FakerContent, FakerContentArgument, FormatContent, RegexContent, StringContent, Uuid,
+    ConstantContent, FakerContent, FakerContentArgument, FormatContent, RegexContent,
+    SlicedContent, StringContent, Uuid,
 };
 
 mod date_time;
@@ -228,7 +229,8 @@ macro_rules! content {
                             let ref_ = FieldRef::deserialize(s.into_deserializer())?;
                             Ok(Content::SameAs(SameAsContent { ref_ }))
                         } else {
-                            Err(E::custom("string literals are synonymous to `same_as` and must start with `@` followed by the address of the referent"))
+                            let a = ConstantContent { content: v.to_string() };
+                            Ok(Content::String(StringContent::Constant(a)))
                         }
                     }
                 }

--- a/core/src/schema/content/mod.rs
+++ b/core/src/schema/content/mod.rs
@@ -229,7 +229,7 @@ macro_rules! content {
                             let ref_ = FieldRef::deserialize(s.into_deserializer())?;
                             Ok(Content::SameAs(SameAsContent { ref_ }))
                         } else {
-                            Ok(Content::String(StringContent::Constant(ConstantContent::from_str(v).unwrap())))
+                            Ok(Content::String(StringContent::Constant(ConstantContent::from(v.to_string()))))
                         }
                     }
                 }

--- a/core/src/schema/content/mod.rs
+++ b/core/src/schema/content/mod.rs
@@ -229,8 +229,7 @@ macro_rules! content {
                             let ref_ = FieldRef::deserialize(s.into_deserializer())?;
                             Ok(Content::SameAs(SameAsContent { ref_ }))
                         } else {
-                            let a = ConstantContent { content: v.to_string() };
-                            Ok(Content::String(StringContent::Constant(a)))
+                            Ok(Content::String(StringContent::Constant(ConstantContent::from_str(v).unwrap())))
                         }
                     }
                 }

--- a/core/src/schema/content/string.rs
+++ b/core/src/schema/content/string.rs
@@ -283,7 +283,7 @@ impl Compile for StringContent {
                 RandomString::from(Sliced::new(content, slice)).into()
             }
             StringContent::Constant(ConstantContent(s)) => {
-                RandomString::from(Constant(s.to_string())).into()
+                RandomString::from(Constant(s.into())).into()
             }
             StringContent::Uuid(_uuid) => RandomString::from(UuidGen {}).into(),
         };

--- a/core/src/schema/content/string.rs
+++ b/core/src/schema/content/string.rs
@@ -2,7 +2,7 @@ use std::hash::{Hash, Hasher};
 
 use super::prelude::*;
 use super::Categorical;
-use crate::graph::string::Serialized;
+use crate::graph::string::{Constant, Serialized, Sliced};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Hash)]
 #[serde(rename_all = "snake_case")]
@@ -14,7 +14,9 @@ pub enum StringContent {
     Serialized(SerializedContent),
     Uuid(Uuid),
     Truncated(TruncatedContent),
+    Sliced(SlicedContent),
     Format(FormatContent),
+    Constant(ConstantContent),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Hash)]
@@ -29,6 +31,8 @@ impl StringContent {
             Self::Serialized(_) => "serialized".to_string(),
             Self::Uuid(_) => "uuid".to_string(),
             Self::Truncated(_) => "truncated".to_string(),
+            Self::Sliced(_) => "sliced".to_string(),
+            Self::Constant(_) => "constant".to_string(),
             Self::Format(_) => "format".to_string(),
         }
     }
@@ -192,6 +196,19 @@ pub struct TruncatedContent {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]
+pub struct SlicedContent {
+    content: Box<Content>,
+    slice: Box<Content>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub struct ConstantContent {
+    pub content: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "lowercase")]
 pub struct FormatContent {
     format: String,
     pub arguments: HashMap<String, Content>,
@@ -253,6 +270,17 @@ impl Compile for StringContent {
                 let content = compiler.build("content", content)?.into_string();
                 let length = compiler.build("length", length)?.into_size();
                 RandomString::from(Truncated::new(content, length)).into()
+            }
+            StringContent::Sliced(SlicedContent {
+                box slice,
+                box content,
+            }) => {
+                let content = compiler.build("content", content)?.into_string();
+                let slice = compiler.build("slice", slice)?.into_string();
+                RandomString::from(Sliced::new(content, slice)).into()
+            }
+            StringContent::Constant(ConstantContent { content }) => {
+                RandomString::from(Constant(content.clone())).into()
             }
             StringContent::Uuid(_uuid) => RandomString::from(UuidGen {}).into(),
         };

--- a/core/src/schema/content/string.rs
+++ b/core/src/schema/content/string.rs
@@ -204,11 +204,9 @@ pub struct SlicedContent {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct ConstantContent(String);
 
-impl FromStr for ConstantContent {
-    type Err = std::convert::Infallible;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(ConstantContent(s.to_string()))
+impl From<String> for ConstantContent {
+    fn from(s: String) -> Self {
+        ConstantContent(s)
     }
 }
 
@@ -285,7 +283,7 @@ impl Compile for StringContent {
                 RandomString::from(Sliced::new(content, slice)).into()
             }
             StringContent::Constant(ConstantContent(s)) => {
-                RandomString::from(Constant(s.clone())).into()
+                RandomString::from(Constant(s.to_string())).into()
             }
             StringContent::Uuid(_uuid) => RandomString::from(UuidGen {}).into(),
         };

--- a/core/src/schema/content/string.rs
+++ b/core/src/schema/content/string.rs
@@ -202,9 +202,14 @@ pub struct SlicedContent {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[serde(rename_all = "lowercase")]
-pub struct ConstantContent {
-    pub content: String,
+pub struct ConstantContent(String);
+
+impl FromStr for ConstantContent {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(ConstantContent(s.to_string()))
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -279,8 +284,8 @@ impl Compile for StringContent {
                 let slice = compiler.build("slice", slice)?.into_string();
                 RandomString::from(Sliced::new(content, slice)).into()
             }
-            StringContent::Constant(ConstantContent { content }) => {
-                RandomString::from(Constant(content.clone())).into()
+            StringContent::Constant(ConstantContent(s)) => {
+                RandomString::from(Constant(s.clone())).into()
             }
             StringContent::Uuid(_uuid) => RandomString::from(UuidGen {}).into(),
         };

--- a/core/src/schema/content/string.rs
+++ b/core/src/schema/content/string.rs
@@ -194,14 +194,14 @@ pub struct TruncatedContent {
     length: Box<Content>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Hash)]
 #[serde(rename_all = "lowercase")]
 pub struct SlicedContent {
     content: Box<Content>,
     slice: Box<Content>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Hash)]
 pub struct ConstantContent(String);
 
 impl From<String> for ConstantContent {
@@ -210,7 +210,7 @@ impl From<String> for ConstantContent {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]
 pub struct FormatContent {
     format: String,

--- a/core/src/schema/inference/mod.rs
+++ b/core/src/schema/inference/mod.rs
@@ -127,6 +127,8 @@ impl MergeStrategy<StringContent, String> for OptionalMergeStrategy {
             StringContent::Serialized(_) => Ok(()), // we can probably do better here
             StringContent::Uuid(_) => Ok(()),
             StringContent::Truncated(_) => Ok(()),
+            StringContent::Sliced(_) => Ok(()),
+            StringContent::Constant(_) => Ok(()),
             StringContent::Format(_) => Ok(()),
         }
     }

--- a/docs/docs/content/string.md
+++ b/docs/docs/content/string.md
@@ -793,6 +793,30 @@ If the output of its inner generator is less than or equal to the length, it is 
 }
 ```
 
+## sliced
+
+The `sliced` generator takes a character slice of a string. 
+
+The slice format is `[start]:[finish]` and if it fails to parse the original string will be returned.
+
+`sliced` has 2 fields,
+- `slice`: A string with a optional start and optional end separated by `:`
+- `content`: The content to be sliced. This can be any Synth generator that yields a String.
+
+#### Example
+
+```json synth
+{
+  "type": "string",
+  "sliced": {
+    "content": {
+      "type": "string",
+      "pattern": "[a-zA-Z0-9]{10, 20}"
+    },
+    "slice": "3:5"
+  }
+}
+```
 
 
 ## categorical

--- a/docs/docs/content/string.md
+++ b/docs/docs/content/string.md
@@ -818,6 +818,28 @@ The slice format is `[start]:[finish]` and if it fails to parse the original str
 }
 ```
 
+## constant
+
+The `constant` generator allows you to generate a constant string. Strings that begin with `@` can
+also be declared constant instead of being treated as a reference, although you need to use the long-form version:
+
+```json synth
+{
+  "type": "string",
+  "constant": "@foobar"
+}
+```
+
+Or shorthand notation if you are declaring an object field:
+
+```json synth
+{
+  "type": "object",
+  "name": "bob"
+}
+```
+
+
 
 ## categorical
 

--- a/synth/src/lib.rs
+++ b/synth/src/lib.rs
@@ -1,11 +1,4 @@
-#![feature(
-    format_args_capture,
-    async_closure,
-    map_first_last,
-    box_patterns,
-    concat_idents,
-    error_iter
-)]
+#![feature(async_closure, map_first_last, box_patterns, concat_idents, error_iter)]
 #![allow(type_alias_bounds)]
 
 #[macro_use]


### PR DESCRIPTION
This is a baby step towards #176 - probably it's better to push this into the formatting library eventually though (along with `truncated` which is just a special-case of slicing) 