### PR TITLE
feat: postgres arrays

### DIFF
--- a/.github/workflows/synth-postgres.yml
+++ b/.github/workflows/synth-postgres.yml
@@ -48,3 +48,5 @@ jobs:
         working-directory: synth/testing_harness/postgres
       - run: ./e2e.sh test-warning
         working-directory: synth/testing_harness/postgres
+      - run: ./e2e.sh test-arrays
+        working-directory: synth/testing_harness/postgres

--- a/core/src/graph/mod.rs
+++ b/core/src/graph/mod.rs
@@ -452,12 +452,10 @@ impl Value {
 
 impl Encode<'_, Postgres> for Value {
     fn produces(&self) -> Option<PgTypeInfo> {
-        let (typ, depth) = self.get_postgres_type();
-
-        if depth > 0 {
-            Some(PgTypeInfo::with_name("text"))
-        } else {
-            Some(PgTypeInfo::with_name(typ))
+        // Only arrays needs a special type
+        match self {
+            Value::Array(_) => Some(PgTypeInfo::with_name("text")),
+            _ => None,
         }
     }
 

--- a/core/src/graph/mod.rs
+++ b/core/src/graph/mod.rs
@@ -371,13 +371,18 @@ impl Value {
     fn to_postgres_string(&self) -> String {
         match self {
             Self::Array(arr) => {
-                format!(
-                    "{{{}}}",
-                    arr.iter()
-                        .map(|v| v.to_postgres_string())
-                        .collect::<Vec<String>>()
-                        .join(", ")
-                )
+                let (typ, _) = self.get_postgres_type();
+                let inner = arr
+                    .iter()
+                    .map(|v| v.to_postgres_string())
+                    .collect::<Vec<String>>()
+                    .join(", ");
+
+                if typ == "jsonb" {
+                    format!("[{}]", inner)
+                } else {
+                    format!("{{{}}}", inner)
+                }
             }
             Self::Null(_) => "NULL".to_string(),
             Self::Bool(b) => b.to_string(),

--- a/core/src/graph/mod.rs
+++ b/core/src/graph/mod.rs
@@ -381,10 +381,16 @@ impl Value {
             }
             Self::Null(_) => "NULL".to_string(),
             Self::Bool(b) => b.to_string(),
-            Self::Number(num) => num.to_string(),
+            Self::Number(num) => match num {
+                Number::F32(f32) => (*f32).to_string(),
+                Number::F64(f64) => (*f64).to_string(),
+                _ => num.to_string(),
+            },
             Self::String(str) => format!("\"{}\"", str),
             Self::DateTime(date) => date.format_to_string(),
-            Self::Object(_) => serde_json::to_string(&self).unwrap(),
+            Self::Object(_) => {
+                serde_json::to_string(&json::synth_val_to_json(self.clone())).unwrap()
+            }
         }
     }
 
@@ -394,6 +400,7 @@ impl Value {
 
         let mut current = Some(self);
 
+        // Based on https://docs.rs/sqlx-core/0.5.9/sqlx_core/postgres/types/index.html
         while let Some(c) = current {
             let pair = match c {
                 Value::Null(_) => (None, "unknown"),

--- a/synth/src/cli/import_utils.rs
+++ b/synth/src/cli/import_utils.rs
@@ -5,7 +5,6 @@ use async_std::task;
 use log::debug;
 use serde_json::Value;
 use std::convert::TryFrom;
-use synth_core::graph::json::synth_val_to_json;
 use synth_core::schema::content::number_content::U64;
 use synth_core::schema::{
     ArrayContent, FieldRef, NumberContent, ObjectContent, OptionalMergeStrategy, RangeStep,
@@ -129,10 +128,9 @@ fn populate_namespace_values<T: DataSource + RelationalDataSource>(
 ) -> Result<()> {
     task::block_on(datasource.set_seed())?;
 
-    for table_name in table_names {
-        let values = task::block_on(datasource.get_deterministic_samples(table_name))?;
-        let json_values: Vec<Value> = values.into_iter().map(synth_val_to_json).collect();
-        namespace.try_update(OptionalMergeStrategy, table_name, &Value::from(json_values))?;
+    for table in table_names {
+        let json_values = task::block_on(datasource.get_deterministic_samples(table))?;
+        namespace.try_update(OptionalMergeStrategy, table, &Value::from(json_values))?;
     }
 
     Ok(())

--- a/synth/src/cli/import_utils.rs
+++ b/synth/src/cli/import_utils.rs
@@ -5,6 +5,7 @@ use async_std::task;
 use log::debug;
 use serde_json::Value;
 use std::convert::TryFrom;
+use synth_core::graph::json::synth_val_to_json;
 use synth_core::schema::content::number_content::U64;
 use synth_core::schema::{
     ArrayContent, FieldRef, NumberContent, ObjectContent, OptionalMergeStrategy, RangeStep,
@@ -128,9 +129,10 @@ fn populate_namespace_values<T: DataSource + RelationalDataSource>(
 ) -> Result<()> {
     task::block_on(datasource.set_seed())?;
 
-    for table in table_names {
-        let json_values = task::block_on(datasource.get_deterministic_samples(table))?;
-        namespace.try_update(OptionalMergeStrategy, table, &Value::from(json_values))?;
+    for table_name in table_names {
+        let values = task::block_on(datasource.get_deterministic_samples(table_name))?;
+        let json_values: Vec<Value> = values.into_iter().map(synth_val_to_json).collect();
+        namespace.try_update(OptionalMergeStrategy, table_name, &Value::from(json_values))?;
     }
 
     Ok(())

--- a/synth/src/datasource/mysql_datasource.rs
+++ b/synth/src/datasource/mysql_datasource.rs
@@ -199,7 +199,11 @@ impl RelationalDataSource for MySqlDataSource {
         Ok(content)
     }
 
-    fn extend_parameterised_query(query: &mut String, _curr_index: usize, query_params: Vec<Value>) {
+    fn extend_parameterised_query(
+        query: &mut String,
+        _curr_index: usize,
+        query_params: Vec<Value>,
+    ) {
         let extend = query_params.len();
 
         query.push('(');

--- a/synth/src/datasource/mysql_datasource.rs
+++ b/synth/src/datasource/mysql_datasource.rs
@@ -9,6 +9,7 @@ use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use sqlx::mysql::{MySqlColumn, MySqlPoolOptions, MySqlQueryResult, MySqlRow};
 use sqlx::{Column, MySql, Pool, Row, TypeInfo};
+use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::prelude::rust_2015::Result::Ok;
 use synth_core::schema::number_content::{F64, I64, U64};
@@ -16,6 +17,7 @@ use synth_core::schema::{
     ChronoValueType, DateTimeContent, NumberContent, RangeStep, RegexContent, StringContent,
 };
 use synth_core::{Content, Value};
+use synth_gen::prelude::*;
 
 /// TODO
 /// Known issues:
@@ -128,7 +130,7 @@ impl RelationalDataSource for MySqlDataSource {
         Ok(())
     }
 
-    async fn get_deterministic_samples(&self, table_name: &str) -> Result<Vec<serde_json::Value>> {
+    async fn get_deterministic_samples(&self, table_name: &str) -> Result<Vec<Value>> {
         let query = format!("SELECT * FROM {} ORDER BY rand(0.5) LIMIT 10", table_name);
 
         sqlx::query(&query)
@@ -271,64 +273,50 @@ impl TryFrom<MySqlRow> for ValueWrapper {
     type Error = anyhow::Error;
 
     fn try_from(row: MySqlRow) -> Result<Self, Self::Error> {
-        let mut kv = serde_json::Map::new();
+        let mut kv = BTreeMap::new();
 
         for column in row.columns() {
-            let value = try_match_value(&row, column).unwrap_or(serde_json::Value::Null);
+            let value = try_match_value(&row, column).unwrap_or(Value::Null(()));
             kv.insert(column.name().to_string(), value);
         }
 
-        Ok(ValueWrapper(serde_json::Value::Object(kv)))
+        Ok(ValueWrapper(Value::Object(kv)))
     }
 }
 
-fn try_match_value(row: &MySqlRow, column: &MySqlColumn) -> Result<serde_json::Value> {
+fn try_match_value(row: &MySqlRow, column: &MySqlColumn) -> Result<Value> {
     let value = match column.type_info().name().to_lowercase().as_str() {
         "char" | "varchar" | "text" | "binary" | "varbinary" | "enum" | "set" => {
-            serde_json::Value::String(row.try_get::<String, &str>(column.name())?)
+            Value::String(row.try_get::<String, &str>(column.name())?)
         }
-        "tinyint" => serde_json::Value::Number(row.try_get::<i8, &str>(column.name())?.into()),
-        "smallint" => serde_json::Value::Number(row.try_get::<i16, &str>(column.name())?.into()),
+        "tinyint" => Value::Number(Number::from(row.try_get::<i8, &str>(column.name())?)),
+        "smallint" => Value::Number(Number::from(row.try_get::<i16, &str>(column.name())?)),
         "mediumint" | "int" | "integer" => {
-            serde_json::Value::Number(row.try_get::<i32, &str>(column.name())?.into())
+            Value::Number(Number::from(row.try_get::<i32, &str>(column.name())?))
         }
-        "bigint" => serde_json::Value::Number(row.try_get::<i64, &str>(column.name())?.into()),
-        "serial" => serde_json::Value::Number(row.try_get::<u64, &str>(column.name())?.into()),
-        "float" => {
-            let f = row.try_get::<f32, &str>(column.name())?;
-            let serde_f = serde_json::Number::from_f64(f as f64)
-                .ok_or_else(|| anyhow!("Failed to convert float4 to number"))?;
-            serde_json::Value::Number(serde_f)
-        }
-        "double" => {
-            let f = row.try_get::<f64, &str>(column.name())?;
-            let serde_f = serde_json::Number::from_f64(f)
-                .ok_or_else(|| anyhow!("Failed to convert float4 to number"))?;
-            serde_json::Value::Number(serde_f)
-        }
+        "bigint" => Value::Number(Number::from(row.try_get::<i64, &str>(column.name())?)),
+        "serial" => Value::Number(Number::from(row.try_get::<u64, &str>(column.name())?)),
+        "float" => Value::Number(Number::from(row.try_get::<f32, &str>(column.name())? as f64)),
+        "double" => Value::Number(Number::from(row.try_get::<f64, &str>(column.name())?)),
         "numeric" | "decimal" => {
             let as_decimal = row.try_get::<Decimal, &str>(column.name())?;
 
             if let Some(truncated) = as_decimal.to_f64() {
-                return Ok(serde_json::Value::Number(
-                    serde_json::Number::from_f64(truncated).ok_or_else(|| {
-                        anyhow!("Failed to convert {} to number", column.type_info().name())
-                    })?,
-                ));
+                return Ok(Value::Number(Number::from(truncated)));
             }
 
             bail!("Failed to convert Mysql numeric data type to 64 bit float")
         }
-        "timestamp" => serde_json::Value::String(row.try_get::<String, &str>(column.name())?),
-        "date" => serde_json::Value::String(format!(
+        "timestamp" => Value::String(row.try_get::<String, &str>(column.name())?),
+        "date" => Value::String(format!(
             "{}",
             row.try_get::<chrono::NaiveDate, &str>(column.name())?
         )),
-        "datetime" => serde_json::Value::String(format!(
+        "datetime" => Value::String(format!(
             "{}",
             row.try_get::<chrono::NaiveDateTime, &str>(column.name())?
         )),
-        "time" => serde_json::Value::String(format!(
+        "time" => Value::String(format!(
             "{}",
             row.try_get::<chrono::NaiveTime, &str>(column.name())?
         )),

--- a/synth/src/datasource/mysql_datasource.rs
+++ b/synth/src/datasource/mysql_datasource.rs
@@ -297,13 +297,13 @@ fn try_match_value(row: &MySqlRow, column: &MySqlColumn) -> Result<serde_json::V
         "float" => {
             let f = row.try_get::<f32, &str>(column.name())?;
             let serde_f = serde_json::Number::from_f64(f as f64)
-                .ok_or(anyhow!("Failed to convert float4 to number"))?;
+                .ok_or_else(|| anyhow!("Failed to convert float4 to number"))?;
             serde_json::Value::Number(serde_f)
         }
         "double" => {
             let f = row.try_get::<f64, &str>(column.name())?;
             let serde_f = serde_json::Number::from_f64(f)
-                .ok_or(anyhow!("Failed to convert float4 to number"))?;
+                .ok_or_else(|| anyhow!("Failed to convert float4 to number"))?;
             serde_json::Value::Number(serde_f)
         }
         "numeric" | "decimal" => {
@@ -311,10 +311,9 @@ fn try_match_value(row: &MySqlRow, column: &MySqlColumn) -> Result<serde_json::V
 
             if let Some(truncated) = as_decimal.to_f64() {
                 return Ok(serde_json::Value::Number(
-                    serde_json::Number::from_f64(truncated).ok_or(anyhow!(
-                        "Failed to convert {} to number",
-                        column.type_info().name()
-                    ))?,
+                    serde_json::Number::from_f64(truncated).ok_or_else(|| {
+                        anyhow!("Failed to convert {} to number", column.type_info().name())
+                    })?,
                 ));
             }
 

--- a/synth/src/datasource/mysql_datasource.rs
+++ b/synth/src/datasource/mysql_datasource.rs
@@ -56,7 +56,7 @@ impl RelationalDataSource for MySqlDataSource {
     async fn execute_query(
         &self,
         query: String,
-        query_params: Vec<&Value>,
+        query_params: Vec<Value>,
     ) -> Result<MySqlQueryResult> {
         let mut query = sqlx::query(query.as_str());
 
@@ -199,7 +199,9 @@ impl RelationalDataSource for MySqlDataSource {
         Ok(content)
     }
 
-    fn extend_parameterised_query(query: &mut String, _curr_index: usize, extend: usize) {
+    fn extend_parameterised_query(query: &mut String, _curr_index: usize, query_params: Vec<Value>) {
+        let extend = query_params.len();
+
         query.push('(');
         for i in 0..extend {
             query.push('?');

--- a/synth/src/datasource/postgres_datasource.rs
+++ b/synth/src/datasource/postgres_datasource.rs
@@ -298,6 +298,8 @@ impl RelationalDataSource for PostgresDataSource {
                 let (typ, depth) = param.get_postgres_type();
                 if typ == "unknown" {
                     "".to_string() // This is currently not supported
+                } else if typ == "jsonb" {
+                    "::jsonb".to_string() // Cannot have an array of jsonb - ie jsonb[]
                 } else {
                     format!("::{}{}", typ, "[]".repeat(depth))
                 }

--- a/synth/src/datasource/postgres_datasource.rs
+++ b/synth/src/datasource/postgres_datasource.rs
@@ -414,13 +414,13 @@ fn try_match_value(row: &PgRow, column: &PgColumn) -> Result<serde_json::Value> 
         "float4" => {
             let f = row.try_get::<f32, &str>(column.name())?;
             let serde_f = serde_json::Number::from_f64(f as f64)
-                .ok_or(anyhow!("Failed to convert float4 to number"))?;
+                .ok_or_else(|| anyhow!("Failed to convert float4 to number"))?;
             serde_json::Value::Number(serde_f)
         }
         "float8" => {
             let f = row.try_get::<f64, &str>(column.name())?;
             let serde_f = serde_json::Number::from_f64(f)
-                .ok_or(anyhow!("Failed to convert float8 to number"))?;
+                .ok_or_else(|| anyhow!("Failed to convert float8 to number"))?;
             serde_json::Value::Number(serde_f)
         }
         "numeric" => {
@@ -429,7 +429,7 @@ fn try_match_value(row: &PgRow, column: &PgColumn) -> Result<serde_json::Value> 
             if let Some(truncated) = as_decimal.to_f64() {
                 return Ok(serde_json::Value::Number(
                     serde_json::Number::from_f64(truncated)
-                        .ok_or(anyhow!("Failed to convert numeric to number"))?,
+                        .ok_or_else(|| anyhow!("Failed to convert numeric to number"))?,
                 ));
             }
 
@@ -448,19 +448,13 @@ fn try_match_value(row: &PgRow, column: &PgColumn) -> Result<serde_json::Value> 
         "json" => row.try_get::<serde_json::Value, &str>(column.name())?,
         "char[]" | "varchar[]" | "text[]" | "citext[]" | "bpchar[]" | "name[]" | "unknown[]" => {
             let vec = row.try_get::<Vec<String>, &str>(column.name())?;
-            let result = vec
-                .into_iter()
-                .map(|s| serde_json::Value::String(s))
-                .collect();
+            let result = vec.into_iter().map(serde_json::Value::String).collect();
 
             serde_json::Value::Array(result)
         }
         "bool[]" => {
             let vec = row.try_get::<Vec<bool>, &str>(column.name())?;
-            let result = vec
-                .into_iter()
-                .map(|b| serde_json::Value::Bool(b))
-                .collect();
+            let result = vec.into_iter().map(serde_json::Value::Bool).collect();
 
             serde_json::Value::Array(result)
         }
@@ -497,7 +491,7 @@ fn try_match_value(row: &PgRow, column: &PgColumn) -> Result<serde_json::Value> 
                 .into_iter()
                 .map(|f| {
                     let serde_f = serde_json::Number::from_f64(f as f64)
-                        .ok_or(anyhow!("Failed to convert float4 to number"))?;
+                        .ok_or_else(|| anyhow!("Failed to convert float4 to number"))?;
                     Ok(serde_json::Value::Number(serde_f))
                 })
                 .collect();
@@ -510,7 +504,7 @@ fn try_match_value(row: &PgRow, column: &PgColumn) -> Result<serde_json::Value> 
                 .into_iter()
                 .map(|f| {
                     let serde_f = serde_json::Number::from_f64(f)
-                        .ok_or(anyhow!("Failed to convert float8 to number"))?;
+                        .ok_or_else(|| anyhow!("Failed to convert float8 to number"))?;
                     Ok(serde_json::Value::Number(serde_f))
                 })
                 .collect();
@@ -525,7 +519,7 @@ fn try_match_value(row: &PgRow, column: &PgColumn) -> Result<serde_json::Value> 
                     if let Some(truncated) = d.to_f64() {
                         return Ok(serde_json::Value::Number(
                             serde_json::Number::from_f64(truncated)
-                                .ok_or(anyhow!("Failed to convert numeric to number"))?,
+                                .ok_or_else(|| anyhow!("Failed to convert numeric to number"))?,
                         ));
                     }
 

--- a/synth/src/datasource/postgres_datasource.rs
+++ b/synth/src/datasource/postgres_datasource.rs
@@ -255,20 +255,20 @@ impl RelationalDataSource for PostgresDataSource {
                     RegexContent::pattern(pattern).context("pattern will always compile")?,
                 ))
             }
-            "int2" => Content::Number(NumberContent::I64(I64::Range(RangeStep::default()))),
+            "int2" => Content::Number(NumberContent::I32(I32::Range(RangeStep::default()))),
             "int4" => Content::Number(NumberContent::I32(I32::Range(RangeStep::default()))),
             "int8" => Content::Number(NumberContent::I64(I64::Range(RangeStep::default()))),
             "float4" => Content::Number(NumberContent::F32(F32::Range(RangeStep::default()))),
             "float8" => Content::Number(NumberContent::F64(F64::Range(RangeStep::default()))),
             "numeric" => Content::Number(NumberContent::F64(F64::Range(RangeStep::default()))),
             "timestamptz" => Content::DateTime(DateTimeContent {
-                format: "".to_string(), // todo
+                format: "%Y-%m-%dT%H:%M:%S%z".to_string(),
                 type_: ChronoValueType::DateTime,
                 begin: None,
                 end: None,
             }),
             "timestamp" => Content::DateTime(DateTimeContent {
-                format: "".to_string(), // todo
+                format: "%Y-%m-%dT%H:%M:%S".to_string(),
                 type_: ChronoValueType::NaiveDateTime,
                 begin: None,
                 end: None,

--- a/synth/src/datasource/postgres_datasource.rs
+++ b/synth/src/datasource/postgres_datasource.rs
@@ -432,7 +432,10 @@ fn try_match_value(row: &PgRow, column: &PgColumn) -> Result<Value> {
             "{}",
             row.try_get::<chrono::NaiveTime, &str>(column.name())?
         )),
-        // "json" => row.try_get::<serde_json::Value, &str>(column.name())?,
+        "json" => {
+            let serde_value = row.try_get::<serde_json::Value, &str>(column.name())?;
+            serde_json::from_value(serde_value)?
+        }
         "char[]" | "varchar[]" | "text[]" | "citext[]" | "bpchar[]" | "name[]" | "unknown[]" => {
             Value::Array(
                 row.try_get::<Vec<String>, &str>(column.name())

--- a/synth/src/datasource/postgres_datasource.rs
+++ b/synth/src/datasource/postgres_datasource.rs
@@ -314,7 +314,7 @@ impl RelationalDataSource for PostgresDataSource {
         let extend = query_params.len();
 
         query.push('(');
-        for (i, param) in query_params.iter().enumerate().take(extend) {
+        for (i, param) in query_params.iter().enumerate() {
             let extra = if let Value::Array(_) = param {
                 let (typ, depth) = param.get_postgres_type();
                 if typ == "unknown" {

--- a/synth/src/datasource/postgres_datasource.rs
+++ b/synth/src/datasource/postgres_datasource.rs
@@ -285,7 +285,7 @@ impl RelationalDataSource for PostgresDataSource {
                 begin: None,
                 end: None,
             }),
-            "json" => Content::Object(ObjectContent {
+            "json" | "jsonb" => Content::Object(ObjectContent {
                 skip_when_null: false,
                 fields: BTreeMap::new(),
             }),
@@ -432,7 +432,7 @@ fn try_match_value(row: &PgRow, column: &PgColumn) -> Result<Value> {
             "{}",
             row.try_get::<chrono::NaiveTime, &str>(column.name())?
         )),
-        "json" => {
+        "json" | "jsonb" => {
             let serde_value = row.try_get::<serde_json::Value, &str>(column.name())?;
             serde_json::from_value(serde_value)?
         }

--- a/synth/src/datasource/postgres_datasource.rs
+++ b/synth/src/datasource/postgres_datasource.rs
@@ -14,8 +14,8 @@ use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use synth_core::schema::number_content::{F32, F64, I32, I64};
 use synth_core::schema::{
-    ArrayContent, BoolContent, Categorical, ChronoValue, ChronoValueAndFormat, ChronoValueType,
-    DateTimeContent, NumberContent, RangeStep, RegexContent, StringContent, Uuid,
+    ArrayContent, BoolContent, Categorical, ChronoValueType, DateTimeContent, NumberContent,
+    ObjectContent, RangeStep, RegexContent, StringContent, Uuid,
 };
 use synth_core::{Content, Value};
 
@@ -216,7 +216,7 @@ impl RelationalDataSource for PostgresDataSource {
 
     /// Must use the singled threaded pool when setting this in conjunction with setseed, called by
     /// [set_seed]. Otherwise, expect big regrets :(
-    async fn get_deterministic_samples(&self, table_name: &str) -> Result<Vec<Value>> {
+    async fn get_deterministic_samples(&self, table_name: &str) -> Result<Vec<serde_json::Value>> {
         let query: &str = &format!("SELECT * FROM {} ORDER BY random() LIMIT 10", table_name);
 
         sqlx::query(query)
@@ -284,6 +284,10 @@ impl RelationalDataSource for PostgresDataSource {
                 type_: ChronoValueType::NaiveTime,
                 begin: None,
                 end: None,
+            }),
+            "json" => Content::Object(ObjectContent {
+                skip_when_null: false,
+                fields: BTreeMap::new(),
             }),
             "uuid" => Content::String(StringContent::Uuid(Uuid)),
             _ => {
@@ -376,155 +380,198 @@ impl TryFrom<PgRow> for ValueWrapper {
     type Error = anyhow::Error;
 
     fn try_from(row: PgRow) -> Result<Self, Self::Error> {
-        let mut kv = BTreeMap::new();
+        let mut kv = serde_json::Map::new();
 
         for column in row.columns() {
             let value = try_match_value(&row, column).unwrap_or_else(|err| {
-                info!("try_match_value failed: {}", err);
-                Value::Null(())
+                debug!("try_match_value failed: {}", err);
+                serde_json::Value::Null
             });
             kv.insert(column.name().to_string(), value);
         }
 
-        Ok(ValueWrapper(Value::Object(kv)))
+        Ok(ValueWrapper(serde_json::Value::Object(kv)))
     }
 }
 
-fn try_match_value(row: &PgRow, column: &PgColumn) -> Result<Value> {
-    if let PgTypeKind::Enum(_) = column.type_info().kind() {
-        let s = row.try_get::<EnumType, &str>(column.name())?;
-        return Ok(Value::String(s.into()));
-    }
+fn try_match_value(row: &PgRow, column: &PgColumn) -> Result<serde_json::Value> {
+    // if let PgTypeKind::Enum(_) = column.type_info().kind() {
+    //     let s = row.try_get::<EnumType, &str>(column.name())?;
+    //     return Ok(Value::String(s.into()));
+    // }
 
     let value = match column.type_info().name().to_lowercase().as_str() {
-        "bool" => Value::Bool(row.try_get::<bool, &str>(column.name())?),
+        "bool" => serde_json::Value::Bool(row.try_get::<bool, &str>(column.name())?),
         "oid" => {
             bail!("OID data type not supported for Postgresql")
         }
         "char" | "varchar" | "text" | "citext" | "bpchar" | "name" | "unknown" => {
-            Value::String(row.try_get::<String, &str>(column.name())?)
+            serde_json::Value::String(row.try_get::<String, &str>(column.name())?)
         }
-        "int2" => Value::Number(row.try_get::<i16, &str>(column.name())?.into()),
-        "int4" => Value::Number(row.try_get::<i32, &str>(column.name())?.into()),
-        "int8" => Value::Number(row.try_get::<i64, &str>(column.name())?.into()),
-        "float4" => Value::Number(row.try_get::<f32, &str>(column.name())?.into()),
-        "float8" => Value::Number(row.try_get::<f64, &str>(column.name())?.into()),
+        "int2" => serde_json::Value::Number(row.try_get::<i16, &str>(column.name())?.into()),
+        "int4" => serde_json::Value::Number(row.try_get::<i32, &str>(column.name())?.into()),
+        "int8" => serde_json::Value::Number(row.try_get::<i64, &str>(column.name())?.into()),
+        "float4" => {
+            let f = row.try_get::<f32, &str>(column.name())?;
+            let serde_f = serde_json::Number::from_f64(f as f64)
+                .ok_or(anyhow!("Failed to convert float4 to number"))?;
+            serde_json::Value::Number(serde_f)
+        }
+        "float8" => {
+            let f = row.try_get::<f64, &str>(column.name())?;
+            let serde_f = serde_json::Number::from_f64(f)
+                .ok_or(anyhow!("Failed to convert float8 to number"))?;
+            serde_json::Value::Number(serde_f)
+        }
         "numeric" => {
             let as_decimal = row.try_get::<Decimal, &str>(column.name())?;
 
             if let Some(truncated) = as_decimal.to_f64() {
-                return Ok(Value::Number(truncated.into()));
+                return Ok(serde_json::Value::Number(
+                    serde_json::Number::from_f64(truncated)
+                        .ok_or(anyhow!("Failed to convert numeric to number"))?,
+                ));
             }
 
             bail!("Failed to convert Postgresql numeric data type to 64 bit float")
         }
-        "timestampz" => Value::String(row.try_get::<String, &str>(column.name())?),
-        "timestamp" => Value::String(row.try_get::<String, &str>(column.name())?),
-        "date" => Value::String(format!(
+        "timestampz" => serde_json::Value::String(row.try_get::<String, &str>(column.name())?),
+        "timestamp" => serde_json::Value::String(row.try_get::<String, &str>(column.name())?),
+        "date" => serde_json::Value::String(format!(
             "{}",
             row.try_get::<chrono::NaiveDate, &str>(column.name())?
         )),
-        "time" => Value::String(format!(
+        "time" => serde_json::Value::String(format!(
             "{}",
             row.try_get::<chrono::NaiveTime, &str>(column.name())?
         )),
+        "json" => row.try_get::<serde_json::Value, &str>(column.name())?,
         "char[]" | "varchar[]" | "text[]" | "citext[]" | "bpchar[]" | "name[]" | "unknown[]" => {
-            Value::Array(
-                row.try_get::<Vec<String>, &str>(column.name())
-                    .map(|vec| vec.iter().map(|s| Value::String(s.to_string())).collect())?,
-            )
+            let vec = row.try_get::<Vec<String>, &str>(column.name())?;
+            let result = vec
+                .into_iter()
+                .map(|s| serde_json::Value::String(s))
+                .collect();
+
+            serde_json::Value::Array(result)
         }
-        "bool[]" => Value::Array(
-            row.try_get::<Vec<bool>, &str>(column.name())
-                .map(|vec| vec.into_iter().map(|b| Value::Bool(b)).collect())?,
-        ),
-        "int2[]" => Value::Array(
-            row.try_get::<Vec<i16>, &str>(column.name())
-                .map(|vec| vec.into_iter().map(|i| Value::Number(i.into())).collect())?,
-        ),
-        "int4[]" => Value::Array(
-            row.try_get::<Vec<i32>, &str>(column.name())
-                .map(|vec| vec.into_iter().map(|i| Value::Number(i.into())).collect())?,
-        ),
-        "int8[]" => Value::Array(
-            row.try_get::<Vec<i64>, &str>(column.name())
-                .map(|vec| vec.into_iter().map(|i| Value::Number(i.into())).collect())?,
-        ),
-        "float4[]" => Value::Array(
-            row.try_get::<Vec<f32>, &str>(column.name())
-                .map(|vec| vec.into_iter().map(|i| Value::Number(i.into())).collect())?,
-        ),
-        "float8[]" => Value::Array(
-            row.try_get::<Vec<f64>, &str>(column.name())
-                .map(|vec| vec.into_iter().map(|i| Value::Number(i.into())).collect())?,
-        ),
+        "bool[]" => {
+            let vec = row.try_get::<Vec<bool>, &str>(column.name())?;
+            let result = vec
+                .into_iter()
+                .map(|b| serde_json::Value::Bool(b))
+                .collect();
+
+            serde_json::Value::Array(result)
+        }
+        "int2[]" => {
+            let vec = row.try_get::<Vec<i16>, &str>(column.name())?;
+            let result = vec
+                .into_iter()
+                .map(|i| serde_json::Value::Number(i.into()))
+                .collect();
+
+            serde_json::Value::Array(result)
+        }
+        "int4[]" => {
+            let vec = row.try_get::<Vec<i32>, &str>(column.name())?;
+            let result = vec
+                .into_iter()
+                .map(|i| serde_json::Value::Number(i.into()))
+                .collect();
+
+            serde_json::Value::Array(result)
+        }
+        "int8[]" => {
+            let vec = row.try_get::<Vec<i64>, &str>(column.name())?;
+            let result = vec
+                .into_iter()
+                .map(|i| serde_json::Value::Number(i.into()))
+                .collect();
+
+            serde_json::Value::Array(result)
+        }
+        "float4[]" => {
+            let vec = row.try_get::<Vec<f32>, &str>(column.name())?;
+            let result: Result<Vec<serde_json::Value>, anyhow::Error> = vec
+                .into_iter()
+                .map(|f| {
+                    let serde_f = serde_json::Number::from_f64(f as f64)
+                        .ok_or(anyhow!("Failed to convert float4 to number"))?;
+                    Ok(serde_json::Value::Number(serde_f))
+                })
+                .collect();
+
+            serde_json::Value::Array(result?)
+        }
+        "float8[]" => {
+            let vec = row.try_get::<Vec<f64>, &str>(column.name())?;
+            let result: Result<Vec<serde_json::Value>, anyhow::Error> = vec
+                .into_iter()
+                .map(|f| {
+                    let serde_f = serde_json::Number::from_f64(f)
+                        .ok_or(anyhow!("Failed to convert float8 to number"))?;
+                    Ok(serde_json::Value::Number(serde_f))
+                })
+                .collect();
+
+            serde_json::Value::Array(result?)
+        }
         "numeric[]" => {
             let vec = row.try_get::<Vec<Decimal>, &str>(column.name())?;
-            let result: Result<Vec<Value>, _> = vec
+            let result: Result<Vec<serde_json::Value>, _> = vec
                 .into_iter()
                 .map(|d| {
                     if let Some(truncated) = d.to_f64() {
-                        return Ok(Value::Number(truncated.into()));
+                        return Ok(serde_json::Value::Number(
+                            serde_json::Number::from_f64(truncated)
+                                .ok_or(anyhow!("Failed to convert numeric to number"))?,
+                        ));
                     }
 
                     bail!("Failed to convert Postgresql numeric data type to 64 bit float")
                 })
                 .collect();
 
-            Value::Array(result?)
+            serde_json::Value::Array(result?)
         }
-        "timestamp[]" => Value::Array(
-            row.try_get::<Vec<chrono::NaiveDateTime>, &str>(column.name())
-                .map(|vec| {
-                    vec.into_iter()
-                        .map(|d| {
-                            Value::DateTime(ChronoValueAndFormat {
-                                format: Arc::from("%Y-%m-%dT%H:%M:%S".to_owned()),
-                                value: ChronoValue::NaiveDateTime(d),
-                            })
-                        })
-                        .collect()
-                })?,
-        ),
-        "timestamptz[]" => Value::Array(
-            row.try_get::<Vec<chrono::DateTime<chrono::FixedOffset>>, &str>(column.name())
-                .map(|vec| {
-                    vec.into_iter()
-                        .map(|d| {
-                            Value::DateTime(ChronoValueAndFormat {
-                                format: Arc::from("%Y-%m-%dT%H:%M:%S%z".to_owned()),
-                                value: ChronoValue::DateTime(d),
-                            })
-                        })
-                        .collect()
-                })?,
-        ),
-        "date[]" => Value::Array(
-            row.try_get::<Vec<chrono::NaiveDate>, &str>(column.name())
-                .map(|vec| {
-                    vec.into_iter()
-                        .map(|d| {
-                            Value::DateTime(ChronoValueAndFormat {
-                                format: Arc::from("%Y-%m-%d".to_owned()),
-                                value: ChronoValue::NaiveDate(d),
-                            })
-                        })
-                        .collect()
-                })?,
-        ),
-        "time[]" => Value::Array(
-            row.try_get::<Vec<chrono::NaiveTime>, &str>(column.name())
-                .map(|vec| {
-                    vec.into_iter()
-                        .map(|t| {
-                            Value::DateTime(ChronoValueAndFormat {
-                                format: Arc::from("%H:%M:%S".to_owned()),
-                                value: ChronoValue::NaiveTime(t),
-                            })
-                        })
-                        .collect()
-                })?,
-        ),
+        "timestamp[]" => {
+            let vec = row.try_get::<Vec<chrono::NaiveDateTime>, &str>(column.name())?;
+            let result = vec
+                .into_iter()
+                .map(|d| serde_json::Value::String(format!("{}", d.format("%Y-%m-%dT%H:%M:%S"))))
+                .collect();
+
+            serde_json::Value::Array(result)
+        }
+        "timestamptz[]" => {
+            let vec =
+                row.try_get::<Vec<chrono::DateTime<chrono::FixedOffset>>, &str>(column.name())?;
+            let result = vec
+                .into_iter()
+                .map(|d| serde_json::Value::String(format!("{}", d.format("%Y-%m-%dT%H:%M:%S%z"))))
+                .collect();
+
+            serde_json::Value::Array(result)
+        }
+        "date[]" => {
+            let vec = row.try_get::<Vec<chrono::NaiveDate>, &str>(column.name())?;
+            let result = vec
+                .into_iter()
+                .map(|d| serde_json::Value::String(format!("{}", d)))
+                .collect();
+
+            serde_json::Value::Array(result)
+        }
+        "time[]" => {
+            let vec = row.try_get::<Vec<chrono::NaiveTime>, &str>(column.name())?;
+            let result = vec
+                .into_iter()
+                .map(|d| serde_json::Value::String(format!("{}", d)))
+                .collect();
+
+            serde_json::Value::Array(result)
+        }
         _ => {
             bail!(
                 "Could not convert value. Converter not implemented for {}",

--- a/synth/src/datasource/postgres_datasource.rs
+++ b/synth/src/datasource/postgres_datasource.rs
@@ -120,7 +120,7 @@ impl RelationalDataSource for PostgresDataSource {
     async fn execute_query(
         &self,
         query: String,
-        query_params: Vec<&Value>,
+        query_params: Vec<Value>,
     ) -> Result<PgQueryResult> {
         let mut query = sqlx::query(query.as_str());
 
@@ -289,10 +289,23 @@ impl RelationalDataSource for PostgresDataSource {
         Ok(content)
     }
 
-    fn extend_parameterised_query(query: &mut String, curr_index: usize, extend: usize) {
+    fn extend_parameterised_query(query: &mut String, curr_index: usize, query_params: Vec<Value>) {
+        let extend = query_params.len();
+
         query.push('(');
-        for i in 0..extend {
-            query.push_str(&format!("${}", curr_index + i + 1));
+        for (i, param) in query_params.iter().enumerate().take(extend) {
+            let extra = if let Value::Array(_) = param {
+                let (typ, depth) = param.get_postgres_type();
+                if typ == "unknown" {
+                    "".to_string() // This is currently not supported
+                } else {
+                    format!("::{}{}", typ, "[]".repeat(depth))
+                }
+            } else {
+                "".to_string()
+            };
+
+            query.push_str(&format!("${}{}", curr_index + i + 1, extra));
             if i != extend - 1 {
                 query.push(',');
             }

--- a/synth/src/datasource/postgres_datasource.rs
+++ b/synth/src/datasource/postgres_datasource.rs
@@ -279,6 +279,12 @@ impl RelationalDataSource for PostgresDataSource {
                 begin: None,
                 end: None,
             }),
+            "time" => Content::DateTime(DateTimeContent {
+                format: "%H:%M:%S".to_string(),
+                type_: ChronoValueType::NaiveTime,
+                begin: None,
+                end: None,
+            }),
             "uuid" => Content::String(StringContent::Uuid(Uuid)),
             _ => {
                 if column_info.data_type.starts_with("_") {

--- a/synth/src/datasource/postgres_datasource.rs
+++ b/synth/src/datasource/postgres_datasource.rs
@@ -287,9 +287,9 @@ impl RelationalDataSource for PostgresDataSource {
             }),
             "uuid" => Content::String(StringContent::Uuid(Uuid)),
             _ => {
-                if column_info.data_type.starts_with("_") {
+                if let Some(data_type) = column_info.data_type.strip_prefix('_') {
                     let mut column_info = column_info.clone();
-                    column_info.data_type = column_info.data_type[1..].to_string();
+                    column_info.data_type = data_type.to_string();
 
                     Content::Array(ArrayContent::from_content_default_length(
                         self.decode_to_content(&column_info)?,

--- a/synth/src/datasource/relational_datasource.rs
+++ b/synth/src/datasource/relational_datasource.rs
@@ -10,7 +10,7 @@ const DEFAULT_INSERT_BATCH_SIZE: usize = 1000;
 
 //TODO: Remove this once https://github.com/rust-lang/rust/issues/88900 gets fixed
 #[allow(dead_code)]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ColumnInfo {
     pub(crate) column_name: String,
     pub(crate) ordinal_position: i32,

--- a/synth/src/datasource/relational_datasource.rs
+++ b/synth/src/datasource/relational_datasource.rs
@@ -111,7 +111,7 @@ pub trait RelationalDataSource: DataSource {
                     .as_object()
                     .expect("This is always an object (sampler contract)");
 
-                let mut curr_query_params : Vec<Value> = row_obj.values().cloned().collect();
+                let mut curr_query_params: Vec<Value> = row_obj.values().cloned().collect();
                 Self::extend_parameterised_query(&mut query, curr_index, curr_query_params.clone());
                 curr_index += curr_query_params.len();
                 query_params.append(&mut curr_query_params);

--- a/synth/src/datasource/relational_datasource.rs
+++ b/synth/src/datasource/relational_datasource.rs
@@ -37,7 +37,7 @@ pub struct ForeignKey {
 
 /// Wrapper around `Value` since we can't impl `TryFrom` on a struct in a non-owned crate
 #[derive(Debug)]
-pub struct ValueWrapper(pub(crate) serde_json::Value);
+pub struct ValueWrapper(pub(crate) Value);
 
 /// All relational databases should define this trait and implement database specific queries in
 /// their own impl. APIs should be defined async when possible, delegating to the caller on how to
@@ -152,7 +152,7 @@ pub trait RelationalDataSource: DataSource {
 
     async fn set_seed(&self) -> Result<()>;
 
-    async fn get_deterministic_samples(&self, table_name: &str) -> Result<Vec<serde_json::Value>>;
+    async fn get_deterministic_samples(&self, table_name: &str) -> Result<Vec<Value>>;
 
     fn decode_to_content(&self, column_info: &ColumnInfo) -> Result<Content>;
 

--- a/synth/src/datasource/relational_datasource.rs
+++ b/synth/src/datasource/relational_datasource.rs
@@ -111,10 +111,10 @@ pub trait RelationalDataSource: DataSource {
                     .as_object()
                     .expect("This is always an object (sampler contract)");
 
-                let extend = row_obj.values().len();
-                Self::extend_parameterised_query(&mut query, curr_index, extend);
-                curr_index += extend;
-                query_params.extend(row_obj.values());
+                let mut curr_query_params : Vec<Value> = row_obj.values().cloned().collect();
+                Self::extend_parameterised_query(&mut query, curr_index, curr_query_params.clone());
+                curr_index += curr_query_params.len();
+                query_params.append(&mut curr_query_params);
 
                 if i == rows.len() - 1 {
                     query.push_str(";\n");
@@ -139,7 +139,7 @@ pub trait RelationalDataSource: DataSource {
     async fn execute_query(
         &self,
         query: String,
-        query_params: Vec<&Value>,
+        query_params: Vec<Value>,
     ) -> Result<Self::QueryResult>;
 
     async fn get_table_names(&self) -> Result<Vec<String>>;
@@ -157,5 +157,5 @@ pub trait RelationalDataSource: DataSource {
     fn decode_to_content(&self, column_info: &ColumnInfo) -> Result<Content>;
 
     // Returns extended query string + current index
-    fn extend_parameterised_query(query: &mut String, curr_index: usize, extend: usize);
+    fn extend_parameterised_query(query: &mut String, curr_index: usize, query_params: Vec<Value>);
 }

--- a/synth/src/datasource/relational_datasource.rs
+++ b/synth/src/datasource/relational_datasource.rs
@@ -37,7 +37,7 @@ pub struct ForeignKey {
 
 /// Wrapper around `Value` since we can't impl `TryFrom` on a struct in a non-owned crate
 #[derive(Debug)]
-pub struct ValueWrapper(pub(crate) Value);
+pub struct ValueWrapper(pub(crate) serde_json::Value);
 
 /// All relational databases should define this trait and implement database specific queries in
 /// their own impl. APIs should be defined async when possible, delegating to the caller on how to
@@ -152,7 +152,7 @@ pub trait RelationalDataSource: DataSource {
 
     async fn set_seed(&self) -> Result<()>;
 
-    async fn get_deterministic_samples(&self, table_name: &str) -> Result<Vec<Value>>;
+    async fn get_deterministic_samples(&self, table_name: &str) -> Result<Vec<serde_json::Value>>;
 
     fn decode_to_content(&self, column_info: &ColumnInfo) -> Result<Content>;
 

--- a/synth/testing_harness/postgres/.gitignore
+++ b/synth/testing_harness/postgres/.gitignore
@@ -1,3 +1,3 @@
 hospital_data_generated.json
-hospital_import
-complete_import
+hospital_import/
+complete_import/

--- a/synth/testing_harness/postgres/.gitignore
+++ b/synth/testing_harness/postgres/.gitignore
@@ -1,3 +1,4 @@
 hospital_data_generated.json
 hospital_import/
 complete_import/
+arrays_import/

--- a/synth/testing_harness/postgres/0_hospital_schema.sql
+++ b/synth/testing_harness/postgres/0_hospital_schema.sql
@@ -8,7 +8,8 @@ create table hospitals
 (
     id            int primary key,
     hospital_name varchar(255),
-    address       varchar(255)
+    address       varchar(255),
+    specialities  varchar(255)[]
 );
 
 create table doctors

--- a/synth/testing_harness/postgres/1_hospital_data.sql
+++ b/synth/testing_harness/postgres/1_hospital_data.sql
@@ -1,20 +1,20 @@
 -- Hospitals
 
-INSERT INTO public.hospitals (id,hospital_name,address) VALUES
-(1,'Garcia-Washington','194 Davis Ferry Suite 232\nJenningsmouth, NV 83701'),
-(2,'Cruz, Bowman and Martinez','1938 Key Wall\nMartinshire, OR 24041'),
-(3,'Bishop, Hartman and Zuniga','574 Snyder Crossing\nPort Christineland, VT 37567'),
-(4,'Maxwell-Garcia','328 Williams Coves\nSmithside, HI 71878'),
-(5,'Potter-Lindsey','5737 Carmen Trace Suite 312\nSouth Evelyn, WY 40089'),
-(6,'Nielsen-Sanchez','70964 Carrillo Burg\nSouth Karichester, ID 67549'),
-(7,'Burch-Daniels','Unit 4839 Box 1083\nDPO AA 25986'),
-(8,'Marshall, Anderson and Jarvis','51322 Joseph Park\nMelissaton, AZ 67575'),
-(9,'Nelson-Jones','8068 David Turnpike\nDelgadoside, FL 82542'),
-(10,'Hall, Wells and Salas','5280 Kelley Crossroad Apt. 574\nLake Davidfort, CT 94005'),
-(11,'Hardy-Obrien','19920 Brian Curve Suite 711\nThompsonville, KY 89805'),
-(12,'Ayala LLC','0079 Michelle Skyway Suite 179\nPort Tony, CA 48596'),
-(13,'Hale-Padilla','19876 Carroll Flats\nClaytonbury, IA 94229'),
-(14,'Jones Inc','82451 Anita Rue Suite 317\nJustintown, WI 30269');
+INSERT INTO public.hospitals (id,hospital_name,address,specialities) VALUES
+(1,'Garcia-Washington','194 Davis Ferry Suite 232\nJenningsmouth, NV 83701', '{"Neurology"}'),
+(2,'Cruz, Bowman and Martinez','1938 Key Wall\nMartinshire, OR 24041', '{"Cardiology"}'),
+(3,'Bishop, Hartman and Zuniga','574 Snyder Crossing\nPort Christineland, VT 37567', '{"Neurology"}'),
+(4,'Maxwell-Garcia','328 Williams Coves\nSmithside, HI 71878', NULL),
+(5,'Potter-Lindsey','5737 Carmen Trace Suite 312\nSouth Evelyn, WY 40089', NULL),
+(6,'Nielsen-Sanchez','70964 Carrillo Burg\nSouth Karichester, ID 67549', '{"Neurology"}'),
+(7,'Burch-Daniels','Unit 4839 Box 1083\nDPO AA 25986', '{"Cardiology"}'),
+(8,'Marshall, Anderson and Jarvis','51322 Joseph Park\nMelissaton, AZ 67575', '{"Cardiology"}'),
+(9,'Nelson-Jones','8068 David Turnpike\nDelgadoside, FL 82542', NULL),
+(10,'Hall, Wells and Salas','5280 Kelley Crossroad Apt. 574\nLake Davidfort, CT 94005', NULL),
+(11,'Hardy-Obrien','19920 Brian Curve Suite 711\nThompsonville, KY 89805', '{"Neurology", "Cardiology"}'),
+(12,'Ayala LLC','0079 Michelle Skyway Suite 179\nPort Tony, CA 48596', '{"Neurology"}'),
+(13,'Hale-Padilla','19876 Carroll Flats\nClaytonbury, IA 94229', '{"Neurology", "Cardiology"}'),
+(14,'Jones Inc','82451 Anita Rue Suite 317\nJustintown, WI 30269', '{"Cardiology", "Neurology"}');
 
 -- Doctors
 

--- a/synth/testing_harness/postgres/arrays/0_arrays.sql
+++ b/synth/testing_harness/postgres/arrays/0_arrays.sql
@@ -21,6 +21,8 @@ CREATE TABLE arrays
     timestamp_array timestamp[],
     timestamptz_array timestamptz[],
     date_array date[],
-    time_array time[]
+    time_array time[],
+    json_array json,
+    jsonb_array json
 );
 

--- a/synth/testing_harness/postgres/arrays/0_arrays.sql
+++ b/synth/testing_harness/postgres/arrays/0_arrays.sql
@@ -1,28 +1,49 @@
 DROP TABLE IF EXISTS arrays;
+DROP TABLE IF EXISTS unofficial_arrays;
 
 CREATE TABLE arrays
 (
-    bool_array boolean[],
-    char_array char[],
-    varchar_array varchar[],
-    name_array name[],
-    string_array text[],
-    smallint_array smallint[],
-    int_array int[],
-    bigint_array bigint[],
-    numeric_array numeric[],
-    usmallint_array smallint[],
-    uint_array int[],
-    ubigint_array bigint[],
-    unumeric_array numeric[],
-    real_array real[],
-    double_precision_array double precision[],
-    int_array_2d int[][],
-    timestamp_array timestamp[],
-    timestamptz_array timestamptz[],
-    date_array date[],
-    time_array time[],
+    boolean_array boolean[] NOT NULL,
+    char_array char[] NOT NULL,
+    varchar_array varchar[] NOT NULL,
+    text_array text[] NOT NULL,
+    bpchar_array text[] NOT NULL,
+    name_array name[] NOT NULL,
+    /* uuid_array uuid[] NOT NULL, */
+    int2_array int2[] NOT NULL,
+    int4_array int4[] NOT NULL,
+    int8_array int8[] NOT NULL,
+    numeric_array numeric[] NOT NULL,
+    uint2_array int2[] NOT NULL,
+    uint4_array int4[] NOT NULL,
+    uint8_array int8[] NOT NULL,
+    unumeric_array numeric[] NOT NULL,
+    float4_array float4[] NOT NULL,
+    float8_array float8[] NOT NULL,
+    int_array_2d int[][] NOT NULL,
+    timestamp_array timestamp[] NOT NULL,
+    timestamptz_array timestamptz[] NOT NULL,
+    date_array date[] NOT NULL,
+    time_array time[] NOT NULL,
     json_array json,
-    jsonb_array json
+    jsonb_array jsonb
 );
 
+CREATE TABLE unofficial_arrays
+(
+    bool_array bool[] NOT NULL,
+    character_array character[] NOT NULL,
+    character_varying_array character varying[] NOT NULL,
+    smallint_array smallint[] NOT NULL,
+    int_array int[] NOT NULL,
+    integer_array integer[] NOT NULL,
+    bigint_array bigint[] NOT NULL,
+    usmallint_array smallint[] NOT NULL,
+    uint_array int[] NOT NULL,
+    uinteger_array integer[] NOT NULL,
+    ubigint_array bigint[] NOT NULL,
+    real_array real[] NOT NULL,
+    double_precision_array double precision[] NOT NULL,
+    decimal_array decimal[] NOT NULL,
+    timestamp_with_time_zone_array timestamp with time zone[] NOT NULL
+);

--- a/synth/testing_harness/postgres/arrays/0_arrays.sql
+++ b/synth/testing_harness/postgres/arrays/0_arrays.sql
@@ -1,0 +1,26 @@
+DROP TABLE IF EXISTS arrays;
+
+CREATE TABLE arrays
+(
+    bool_array boolean[],
+    char_array char[],
+    varchar_array varchar[],
+    name_array name[],
+    string_array text[],
+    smallint_array smallint[],
+    int_array int[],
+    bigint_array bigint[],
+    numeric_array numeric[],
+    usmallint_array smallint[],
+    uint_array int[],
+    ubigint_array bigint[],
+    unumeric_array numeric[],
+    real_array real[],
+    double_precision_array double precision[],
+    int_array_2d int[][],
+    timestamp_array timestamp[],
+    timestamptz_array timestamptz[],
+    date_array date[],
+    time_array time[]
+);
+

--- a/synth/testing_harness/postgres/arrays/arrays.json
+++ b/synth/testing_harness/postgres/arrays/arrays.json
@@ -1,0 +1,388 @@
+{
+    "type": "array",
+    "content": {
+        "type": "object",
+        "bool_array": {
+            "type": "array",
+            "length": {
+                "type": "number",
+                "range": {
+                    "low": 1,
+                    "high": 10,
+                    "step": 1
+                }
+            },
+            "content": {
+                "type": "bool",
+                "frequency": 0.5
+            }
+        },
+        "char_array": {
+            "type": "array",
+            "length": {
+                "type": "number",
+                "range": {
+                    "low": 1,
+                    "high": 10,
+                    "step": 1
+                }
+            },
+            "content": {
+                "type": "string",
+                "pattern": "[a-z]"
+            }
+        },
+        "varchar_array": {
+            "type": "array",
+            "length": {
+                "type": "number",
+                "range": {
+                    "low": 1,
+                    "high": 10,
+                    "step": 1
+                }
+            },
+            "content": {
+                "type": "string",
+                "faker": {
+                    "generator": "company_name"
+                }
+            }
+        },
+        "name_array": {
+            "type": "array",
+            "length": {
+                "type": "number",
+                "range": {
+                    "low": 1,
+                    "high": 10,
+                    "step": 1
+                }
+            },
+            "content": {
+                "type": "string",
+                "faker": {
+                    "generator": "username"
+                }
+            }
+        },
+        "string_array": {
+            "type": "array",
+            "length": {
+                "type": "number",
+                "range": {
+                    "low": 1,
+                    "high": 10,
+                    "step": 1
+                }
+            },
+            "content": {
+                "type": "string",
+                "faker": {
+                    "generator": "name"
+                }
+            }
+        },
+        "smallint_array": {
+            "type": "array",
+            "length": {
+                "type": "number",
+                "range": {
+                    "low": 1,
+                    "high": 10,
+                    "step": 1
+                }
+            },
+            "content": {
+                "type": "number",
+                "subtype": "i32",
+                "range": {
+                    "low": -32766,
+                    "high": 32767,
+                    "step": 1
+                }
+            }
+        },
+        "int_array": {
+            "type": "array",
+            "length": {
+                "type": "number",
+                "range": {
+                    "low": 1,
+                    "high": 10,
+                    "step": 1
+                }
+            },
+            "content": {
+                "type": "number",
+                "subtype": "i32",
+                "range": {
+                    "low": -32766,
+                    "high": 32767,
+                    "step": 1
+                }
+            }
+        },
+        "bigint_array": {
+            "type": "array",
+            "length": {
+                "type": "number",
+                "range": {
+                    "low": 1,
+                    "high": 10,
+                    "step": 1
+                }
+            },
+            "content": {
+                "type": "number",
+                "subtype": "i64",
+                "range": {
+                    "low": -32766,
+                    "high": 32767,
+                    "step": 1
+                }
+            }
+        },
+        "numeric_array": {
+            "type": "array",
+            "length": {
+                "type": "number",
+                "range": {
+                    "low": 1,
+                    "high": 10,
+                    "step": 1
+                }
+            },
+            "content": {
+                "type": "number",
+                "subtype": "i64",
+                "range": {
+                    "low": -32766,
+                    "high": 32767,
+                    "step": 1
+                }
+            }
+        },
+        "usmallint_array": {
+            "type": "array",
+            "length": {
+                "type": "number",
+                "range": {
+                    "low": 1,
+                    "high": 10,
+                    "step": 1
+                }
+            },
+            "content": {
+                "type": "number",
+                "subtype": "u32",
+                "range": {
+                    "low": 0,
+                    "high": 32767,
+                    "step": 1
+                }
+            }
+        },
+        "uint_array": {
+            "type": "array",
+            "length": {
+                "type": "number",
+                "range": {
+                    "low": 1,
+                    "high": 10,
+                    "step": 1
+                }
+            },
+            "content": {
+                "type": "number",
+                "subtype": "u32",
+                "range": {
+                    "low": 0,
+                    "high": 32767,
+                    "step": 1
+                }
+            }
+        },
+        "ubigint_array": {
+            "type": "array",
+            "length": {
+                "type": "number",
+                "range": {
+                    "low": 1,
+                    "high": 10,
+                    "step": 1
+                }
+            },
+            "content": {
+                "type": "number",
+                "subtype": "u64",
+                "range": {
+                    "low": 0,
+                    "high": 32767,
+                    "step": 1
+                }
+            }
+        },
+        "unumeric_array": {
+            "type": "array",
+            "length": {
+                "type": "number",
+                "range": {
+                    "low": 1,
+                    "high": 10,
+                    "step": 1
+                }
+            },
+            "content": {
+                "type": "number",
+                "subtype": "u64",
+                "range": {
+                    "low": 0,
+                    "high": 32767,
+                    "step": 1
+                }
+            }
+        },
+        "real_array": {
+            "type": "array",
+            "length": {
+                "type": "number",
+                "range": {
+                    "low": 1,
+                    "high": 10,
+                    "step": 1
+                }
+            },
+            "content": {
+                "type": "number",
+                "subtype": "f32",
+                "range": {
+                    "low": -32766,
+                    "high": 32767,
+                    "step": 1
+                }
+            }
+        },
+        "double_precision_array": {
+            "type": "array",
+            "length": {
+                "type": "number",
+                "range": {
+                    "low": 1,
+                    "high": 10,
+                    "step": 1
+                }
+            },
+            "content": {
+                "type": "number",
+                "subtype": "f64",
+                "range": {
+                    "low": -32766,
+                    "high": 32767,
+                    "step": 1
+                }
+            }
+        },
+        "int_array_2d": {
+            "type": "array",
+            "length": {
+                "type": "number",
+                "range": {
+                    "low": 1,
+                    "high": 8,
+                    "step": 1
+                },
+                "subtype": "u64"
+            },
+            "content": {
+                "type": "array",
+                "length": {
+                    "type": "number",
+                    "constant": 8
+                },
+                "content": {
+                    "type": "number",
+                    "subtype": "i32",
+                    "range": {
+                        "low": -32768,
+                        "high": 32767,
+                        "step": 1
+                    }
+                }
+            }
+        },
+        "timestamp_array": {
+            "type": "array",
+            "length": {
+                "type": "number",
+                "range": {
+                    "low": 1,
+                    "high": 10,
+                    "step": 1
+                }
+            },
+            "content": {
+                "type": "date_time",
+                "format": "%Y-%m-%dT%H:%M:%S",
+                "subtype": "naive_date_time",
+                "begin": "2015-01-01T00:00:00",
+                "end": "2020-01-01T12:00:00"
+            }
+        },
+        "timestamptz_array": {
+            "type": "array",
+            "length": {
+                "type": "number",
+                "range": {
+                    "low": 1,
+                    "high": 10,
+                    "step": 1
+                }
+            },
+            "content": {
+                "type": "date_time",
+                "format": "%Y-%m-%dT%H:%M:%S%z",
+                "subtype": "date_time",
+                "begin": "2015-01-01T00:00:00+0000",
+                "end": "2020-01-01T12:00:00+0000"
+            }
+        },
+        "date_array": {
+            "type": "array",
+            "length": {
+                "type": "number",
+                "range": {
+                    "low": 1,
+                    "high": 10,
+                    "step": 1
+                }
+            },
+            "content": {
+                "type": "date_time",
+                "format": "%Y-%m-%d",
+                "subtype": "naive_date",
+                "begin": "2015-01-01",
+                "end": "2020-01-01"
+            }
+        },
+        "time_array": {
+            "type": "array",
+            "length": {
+                "type": "number",
+                "range": {
+                    "low": 1,
+                    "high": 10,
+                    "step": 1
+                }
+            },
+            "content": {
+                "type": "date_time",
+                "format": "%H:%M:%S",
+                "subtype": "naive_time",
+                "begin": "00:00:00",
+                "end": "23:00:00"
+            }
+        }
+    },
+    "length": 10
+}

--- a/synth/testing_harness/postgres/arrays/arrays.json
+++ b/synth/testing_harness/postgres/arrays/arrays.json
@@ -382,6 +382,72 @@
                 "begin": "00:00:00",
                 "end": "23:00:00"
             }
+        },
+        "json_array": {
+            "type": "array",
+            "length": {
+                "type": "number",
+                "range": {
+                    "low": 1,
+                    "high": 10,
+                    "step": 1
+                }
+            },
+            "content": {
+                "type": "object",
+                "username": {
+                    "type": "string",
+                    "faker": {
+                        "generator": "username"
+                    }
+                },
+                "scores": {
+                    "type": "array",
+                    "length": 5,
+                    "content": {
+                        "type": "number",
+                        "subtype": "u32",
+                        "range": {
+                            "low": 0,
+                            "high": 100,
+                            "step": 1
+                        }
+                    }
+                }
+            }
+        },
+        "jsonb_array": {
+            "type": "array",
+            "length": {
+                "type": "number",
+                "range": {
+                    "low": 1,
+                    "high": 10,
+                    "step": 1
+                }
+            },
+            "content": {
+                "type": "object",
+                "username": {
+                    "type": "string",
+                    "faker": {
+                        "generator": "username"
+                    }
+                },
+                "scores": {
+                    "type": "array",
+                    "length": 5,
+                    "content": {
+                        "type": "number",
+                        "subtype": "u32",
+                        "range": {
+                            "low": 0,
+                            "high": 100,
+                            "step": 1
+                        }
+                    }
+                }
+            }
         }
     },
     "length": 10

--- a/synth/testing_harness/postgres/arrays/arrays.json
+++ b/synth/testing_harness/postgres/arrays/arrays.json
@@ -155,7 +155,7 @@
             },
             "content": {
                 "type": "number",
-                "subtype": "i64",
+                "subtype": "f64",
                 "range": {
                     "low": -32766,
                     "high": 32767,
@@ -235,7 +235,7 @@
             },
             "content": {
                 "type": "number",
-                "subtype": "u64",
+                "subtype": "f64",
                 "range": {
                     "low": 0,
                     "high": 32767,

--- a/synth/testing_harness/postgres/arrays/unofficial_arrays.json
+++ b/synth/testing_harness/postgres/arrays/unofficial_arrays.json
@@ -2,7 +2,7 @@
     "type": "array",
     "content": {
         "type": "object",
-        "boolean_array": {
+        "bool_array": {
             "type": "array",
             "length": {
                 "type": "number",
@@ -17,7 +17,7 @@
                 "frequency": 0.5
             }
         },
-        "char_array": {
+        "character_array": {
             "type": "array",
             "length": {
                 "type": "number",
@@ -32,7 +32,7 @@
                 "pattern": "[a-z]"
             }
         },
-        "varchar_array": {
+        "character_varying_array": {
             "type": "array",
             "length": {
                 "type": "number",
@@ -49,58 +49,7 @@
                 }
             }
         },
-        "text_array": {
-            "type": "array",
-            "length": {
-                "type": "number",
-                "range": {
-                    "low": 1,
-                    "high": 10,
-                    "step": 1
-                }
-            },
-            "content": {
-                "type": "string",
-                "faker": {
-                    "generator": "name"
-                }
-            }
-        },
-        "bpchar_array": {
-            "type": "array",
-            "length": {
-                "type": "number",
-                "range": {
-                    "low": 1,
-                    "high": 10,
-                    "step": 1
-                }
-            },
-            "content": {
-                "type": "string",
-                "faker": {
-                    "generator": "title"
-                }
-            }
-        },
-        "name_array": {
-            "type": "array",
-            "length": {
-                "type": "number",
-                "range": {
-                    "low": 1,
-                    "high": 10,
-                    "step": 1
-                }
-            },
-            "content": {
-                "type": "string",
-                "faker": {
-                    "generator": "username"
-                }
-            }
-        },
-        "int2_array": {
+        "smallint_array": {
             "type": "array",
             "length": {
                 "type": "number",
@@ -120,7 +69,7 @@
                 }
             }
         },
-        "int4_array": {
+        "int_array": {
             "type": "array",
             "length": {
                 "type": "number",
@@ -140,7 +89,27 @@
                 }
             }
         },
-        "int8_array": {
+        "integer_array": {
+            "type": "array",
+            "length": {
+                "type": "number",
+                "range": {
+                    "low": 1,
+                    "high": 10,
+                    "step": 1
+                }
+            },
+            "content": {
+                "type": "number",
+                "subtype": "i32",
+                "range": {
+                    "low": -32766,
+                    "high": 32767,
+                    "step": 1
+                }
+            }
+        },
+        "bigint_array": {
             "type": "array",
             "length": {
                 "type": "number",
@@ -160,27 +129,7 @@
                 }
             }
         },
-        "numeric_array": {
-            "type": "array",
-            "length": {
-                "type": "number",
-                "range": {
-                    "low": 1,
-                    "high": 10,
-                    "step": 1
-                }
-            },
-            "content": {
-                "type": "number",
-                "subtype": "f64",
-                "range": {
-                    "low": -32766,
-                    "high": 32767,
-                    "step": 0.01
-                }
-            }
-        },
-        "uint2_array": {
+        "usmallint_array": {
             "type": "array",
             "length": {
                 "type": "number",
@@ -200,7 +149,7 @@
                 }
             }
         },
-        "uint4_array": {
+        "uint_array": {
             "type": "array",
             "length": {
                 "type": "number",
@@ -220,7 +169,27 @@
                 }
             }
         },
-        "uint8_array": {
+        "uinteger_array": {
+            "type": "array",
+            "length": {
+                "type": "number",
+                "range": {
+                    "low": 1,
+                    "high": 10,
+                    "step": 1
+                }
+            },
+            "content": {
+                "type": "number",
+                "subtype": "u32",
+                "range": {
+                    "low": 0,
+                    "high": 32767,
+                    "step": 1
+                }
+            }
+        },
+        "ubigint_array": {
             "type": "array",
             "length": {
                 "type": "number",
@@ -240,27 +209,7 @@
                 }
             }
         },
-        "unumeric_array": {
-            "type": "array",
-            "length": {
-                "type": "number",
-                "range": {
-                    "low": 1,
-                    "high": 10,
-                    "step": 1
-                }
-            },
-            "content": {
-                "type": "number",
-                "subtype": "f64",
-                "range": {
-                    "low": 0,
-                    "high": 32767,
-                    "step": 0.01
-                }
-            }
-        },
-        "float4_array": {
+        "real_array": {
             "type": "array",
             "length": {
                 "type": "number",
@@ -280,7 +229,7 @@
                 }
             }
         },
-        "float8_array": {
+        "double_precision_array": {
             "type": "array",
             "length": {
                 "type": "number",
@@ -300,35 +249,7 @@
                 }
             }
         },
-        "int_array_2d": {
-            "type": "array",
-            "length": {
-                "type": "number",
-                "range": {
-                    "low": 1,
-                    "high": 8,
-                    "step": 1
-                },
-                "subtype": "u64"
-            },
-            "content": {
-                "type": "array",
-                "length": {
-                    "type": "number",
-                    "constant": 8
-                },
-                "content": {
-                    "type": "number",
-                    "subtype": "i32",
-                    "range": {
-                        "low": -32768,
-                        "high": 32767,
-                        "step": 1
-                    }
-                }
-            }
-        },
-        "timestamp_array": {
+        "decimal_array": {
             "type": "array",
             "length": {
                 "type": "number",
@@ -339,14 +260,16 @@
                 }
             },
             "content": {
-                "type": "date_time",
-                "format": "%Y-%m-%dT%H:%M:%S",
-                "subtype": "naive_date_time",
-                "begin": "2015-01-01T00:00:00",
-                "end": "2020-01-01T12:00:00"
+                "type": "number",
+                "subtype": "f64",
+                "range": {
+                    "low": -32766,
+                    "high": 32767,
+                    "step": 0.01
+                }
             }
         },
-        "timestamptz_array": {
+        "timestamp_with_time_zone_array": {
             "type": "array",
             "length": {
                 "type": "number",
@@ -362,108 +285,6 @@
                 "subtype": "date_time",
                 "begin": "2015-01-01T00:00:00+0000",
                 "end": "2020-01-01T12:00:00+0000"
-            }
-        },
-        "date_array": {
-            "type": "array",
-            "length": {
-                "type": "number",
-                "range": {
-                    "low": 1,
-                    "high": 10,
-                    "step": 1
-                }
-            },
-            "content": {
-                "type": "date_time",
-                "format": "%Y-%m-%d",
-                "subtype": "naive_date",
-                "begin": "2015-01-01",
-                "end": "2020-01-01"
-            }
-        },
-        "time_array": {
-            "type": "array",
-            "length": {
-                "type": "number",
-                "range": {
-                    "low": 1,
-                    "high": 10,
-                    "step": 1
-                }
-            },
-            "content": {
-                "type": "date_time",
-                "format": "%H:%M:%S",
-                "subtype": "naive_time",
-                "begin": "00:00:00",
-                "end": "23:00:00"
-            }
-        },
-        "json_array": {
-            "type": "array",
-            "length": {
-                "type": "number",
-                "range": {
-                    "low": 1,
-                    "high": 10,
-                    "step": 1
-                }
-            },
-            "content": {
-                "type": "object",
-                "username": {
-                    "type": "string",
-                    "faker": {
-                        "generator": "username"
-                    }
-                },
-                "scores": {
-                    "type": "array",
-                    "length": 5,
-                    "content": {
-                        "type": "number",
-                        "subtype": "u32",
-                        "range": {
-                            "low": 0,
-                            "high": 100,
-                            "step": 1
-                        }
-                    }
-                }
-            }
-        },
-        "jsonb_array": {
-            "type": "array",
-            "length": {
-                "type": "number",
-                "range": {
-                    "low": 1,
-                    "high": 10,
-                    "step": 1
-                }
-            },
-            "content": {
-                "type": "object",
-                "username": {
-                    "type": "string",
-                    "faker": {
-                        "generator": "username"
-                    }
-                },
-                "scores": {
-                    "type": "array",
-                    "length": 5,
-                    "content": {
-                        "type": "number",
-                        "subtype": "u32",
-                        "range": {
-                            "low": 0,
-                            "high": 100,
-                            "step": 1
-                        }
-                    }
-                }
             }
         }
     },

--- a/synth/testing_harness/postgres/arrays_master/arrays.json
+++ b/synth/testing_harness/postgres/arrays_master/arrays.json
@@ -21,14 +21,17 @@
             "type": "number",
             "range": {
               "low": 1,
-              "high": 2,
+              "high": 9,
               "step": 1
             },
             "subtype": "u64"
           },
           "content": {
             "type": "number",
-            "range": {},
+            "range": {
+              "low": -31059,
+              "high": 30176
+            },
             "subtype": "i64"
           }
         },
@@ -48,7 +51,7 @@
             "type": "number",
             "range": {
               "low": 1,
-              "high": 2,
+              "high": 9,
               "step": 1
             },
             "subtype": "u64"
@@ -74,7 +77,7 @@
             "type": "number",
             "range": {
               "low": 1,
-              "high": 2,
+              "high": 9,
               "step": 1
             },
             "subtype": "u64"
@@ -100,7 +103,7 @@
             "type": "number",
             "range": {
               "low": 1,
-              "high": 2,
+              "high": 7,
               "step": 1
             },
             "subtype": "u64"
@@ -108,7 +111,9 @@
           "content": {
             "type": "date_time",
             "format": "%Y-%m-%d",
-            "subtype": "naive_date"
+            "subtype": "naive_date",
+            "begin": "2015-01-02",
+            "end": "2019-12-08"
           }
         },
         {
@@ -127,14 +132,17 @@
             "type": "number",
             "range": {
               "low": 1,
-              "high": 2,
+              "high": 9,
               "step": 1
             },
             "subtype": "u64"
           },
           "content": {
             "type": "number",
-            "range": {},
+            "range": {
+              "low": -31782.0,
+              "high": 28982.0
+            },
             "subtype": "f64"
           }
         },
@@ -154,14 +162,17 @@
             "type": "number",
             "range": {
               "low": 1,
-              "high": 2,
+              "high": 7,
               "step": 1
             },
             "subtype": "u64"
           },
           "content": {
             "type": "number",
-            "range": {},
+            "range": {
+              "low": -27025,
+              "high": 31240
+            },
             "subtype": "i32"
           }
         },
@@ -208,7 +219,7 @@
             "type": "number",
             "range": {
               "low": 1,
-              "high": 2,
+              "high": 8,
               "step": 1
             },
             "subtype": "u64"
@@ -234,14 +245,17 @@
             "type": "number",
             "range": {
               "low": 1,
-              "high": 2,
+              "high": 9,
               "step": 1
             },
             "subtype": "u64"
           },
           "content": {
             "type": "number",
-            "range": {},
+            "range": {
+              "low": -32371.0,
+              "high": 31915.0
+            },
             "subtype": "f64"
           }
         },
@@ -261,14 +275,17 @@
             "type": "number",
             "range": {
               "low": 1,
-              "high": 2,
+              "high": 9,
               "step": 1
             },
             "subtype": "u64"
           },
           "content": {
             "type": "number",
-            "range": {},
+            "range": {
+              "low": -32448.0,
+              "high": 32168.0
+            },
             "subtype": "f32"
           }
         },
@@ -288,14 +305,17 @@
             "type": "number",
             "range": {
               "low": 1,
-              "high": 2,
+              "high": 8,
               "step": 1
             },
             "subtype": "u64"
           },
           "content": {
             "type": "number",
-            "range": {},
+            "range": {
+              "low": -31050,
+              "high": 32734
+            },
             "subtype": "i32"
           }
         },
@@ -315,7 +335,7 @@
             "type": "number",
             "range": {
               "low": 1,
-              "high": 2,
+              "high": 9,
               "step": 1
             },
             "subtype": "u64"
@@ -341,7 +361,7 @@
             "type": "number",
             "range": {
               "low": 1,
-              "high": 2,
+              "high": 8,
               "step": 1
             },
             "subtype": "u64"
@@ -349,7 +369,9 @@
           "content": {
             "type": "date_time",
             "format": "%H:%M:%S",
-            "subtype": "naive_time"
+            "subtype": "naive_time",
+            "begin": "00:11:49",
+            "end": "22:59:22"
           }
         },
         {
@@ -368,7 +390,7 @@
             "type": "number",
             "range": {
               "low": 1,
-              "high": 2,
+              "high": 9,
               "step": 1
             },
             "subtype": "u64"
@@ -376,7 +398,9 @@
           "content": {
             "type": "date_time",
             "format": "%Y-%m-%dT%H:%M:%S",
-            "subtype": "naive_date_time"
+            "subtype": "naive_date_time",
+            "begin": "2015-01-01T03:04:18",
+            "end": "2019-12-16T02:02:24"
           }
         },
         {
@@ -395,7 +419,7 @@
             "type": "number",
             "range": {
               "low": 1,
-              "high": 2,
+              "high": 9,
               "step": 1
             },
             "subtype": "u64"
@@ -403,7 +427,9 @@
           "content": {
             "type": "date_time",
             "format": "%Y-%m-%dT%H:%M:%S%z",
-            "subtype": "date_time"
+            "subtype": "date_time",
+            "begin": "2015-02-13T10:58:51+0000",
+            "end": "2019-12-24T00:22:16+0000"
           }
         },
         {
@@ -422,14 +448,17 @@
             "type": "number",
             "range": {
               "low": 1,
-              "high": 2,
+              "high": 9,
               "step": 1
             },
             "subtype": "u64"
           },
           "content": {
             "type": "number",
-            "range": {},
+            "range": {
+              "low": 176,
+              "high": 32112
+            },
             "subtype": "i64"
           }
         },
@@ -449,14 +478,17 @@
             "type": "number",
             "range": {
               "low": 1,
-              "high": 2,
+              "high": 8,
               "step": 1
             },
             "subtype": "u64"
           },
           "content": {
             "type": "number",
-            "range": {},
+            "range": {
+              "low": 901,
+              "high": 32145
+            },
             "subtype": "i32"
           }
         },
@@ -476,14 +508,17 @@
             "type": "number",
             "range": {
               "low": 1,
-              "high": 2,
+              "high": 8,
               "step": 1
             },
             "subtype": "u64"
           },
           "content": {
             "type": "number",
-            "range": {},
+            "range": {
+              "low": 1152.0,
+              "high": 32038.0
+            },
             "subtype": "f64"
           }
         },
@@ -503,14 +538,17 @@
             "type": "number",
             "range": {
               "low": 1,
-              "high": 2,
+              "high": 9,
               "step": 1
             },
             "subtype": "u64"
           },
           "content": {
             "type": "number",
-            "range": {},
+            "range": {
+              "low": 596,
+              "high": 32691
+            },
             "subtype": "i32"
           }
         },
@@ -530,7 +568,7 @@
             "type": "number",
             "range": {
               "low": 1,
-              "high": 2,
+              "high": 9,
               "step": 1
             },
             "subtype": "u64"

--- a/synth/testing_harness/postgres/arrays_master/arrays.json
+++ b/synth/testing_harness/postgres/arrays_master/arrays.json
@@ -1,0 +1,550 @@
+{
+  "type": "array",
+  "length": {
+    "type": "number",
+    "range": {
+      "low": 1,
+      "high": 10,
+      "step": 1
+    },
+    "subtype": "u64"
+  },
+  "content": {
+    "type": "object",
+    "bigint_array": {
+      "type": "one_of",
+      "variants": [
+        {
+          "weight": 1.0,
+          "type": "array",
+          "length": {
+            "type": "number",
+            "range": {
+              "low": 1,
+              "high": 2,
+              "step": 1
+            },
+            "subtype": "u64"
+          },
+          "content": {
+            "type": "number",
+            "range": {},
+            "subtype": "i64"
+          }
+        },
+        {
+          "weight": 1.0,
+          "type": "null"
+        }
+      ]
+    },
+    "bool_array": {
+      "type": "one_of",
+      "variants": [
+        {
+          "weight": 1.0,
+          "type": "array",
+          "length": {
+            "type": "number",
+            "range": {
+              "low": 1,
+              "high": 2,
+              "step": 1
+            },
+            "subtype": "u64"
+          },
+          "content": {
+            "type": "bool",
+            "frequency": 0.5
+          }
+        },
+        {
+          "weight": 1.0,
+          "type": "null"
+        }
+      ]
+    },
+    "char_array": {
+      "type": "one_of",
+      "variants": [
+        {
+          "weight": 1.0,
+          "type": "array",
+          "length": {
+            "type": "number",
+            "range": {
+              "low": 1,
+              "high": 2,
+              "step": 1
+            },
+            "subtype": "u64"
+          },
+          "content": {
+            "type": "string",
+            "pattern": "[a-zA-Z0-9]{0, 1}"
+          }
+        },
+        {
+          "weight": 1.0,
+          "type": "null"
+        }
+      ]
+    },
+    "date_array": {
+      "type": "one_of",
+      "variants": [
+        {
+          "weight": 1.0,
+          "type": "array",
+          "length": {
+            "type": "number",
+            "range": {
+              "low": 1,
+              "high": 2,
+              "step": 1
+            },
+            "subtype": "u64"
+          },
+          "content": {
+            "type": "date_time",
+            "format": "%Y-%m-%d",
+            "subtype": "naive_date"
+          }
+        },
+        {
+          "weight": 1.0,
+          "type": "null"
+        }
+      ]
+    },
+    "double_precision_array": {
+      "type": "one_of",
+      "variants": [
+        {
+          "weight": 1.0,
+          "type": "array",
+          "length": {
+            "type": "number",
+            "range": {
+              "low": 1,
+              "high": 2,
+              "step": 1
+            },
+            "subtype": "u64"
+          },
+          "content": {
+            "type": "number",
+            "range": {},
+            "subtype": "f64"
+          }
+        },
+        {
+          "weight": 1.0,
+          "type": "null"
+        }
+      ]
+    },
+    "int_array": {
+      "type": "one_of",
+      "variants": [
+        {
+          "weight": 1.0,
+          "type": "array",
+          "length": {
+            "type": "number",
+            "range": {
+              "low": 1,
+              "high": 2,
+              "step": 1
+            },
+            "subtype": "u64"
+          },
+          "content": {
+            "type": "number",
+            "range": {},
+            "subtype": "i32"
+          }
+        },
+        {
+          "weight": 1.0,
+          "type": "null"
+        }
+      ]
+    },
+    "int_array_2d": {
+      "type": "one_of",
+      "variants": [
+        {
+          "weight": 1.0,
+          "type": "array",
+          "length": {
+            "type": "number",
+            "range": {
+              "low": 1,
+              "high": 2,
+              "step": 1
+            },
+            "subtype": "u64"
+          },
+          "content": {
+            "type": "number",
+            "range": {},
+            "subtype": "i32"
+          }
+        },
+        {
+          "weight": 1.0,
+          "type": "null"
+        }
+      ]
+    },
+    "name_array": {
+      "type": "one_of",
+      "variants": [
+        {
+          "weight": 1.0,
+          "type": "array",
+          "length": {
+            "type": "number",
+            "range": {
+              "low": 1,
+              "high": 2,
+              "step": 1
+            },
+            "subtype": "u64"
+          },
+          "content": {
+            "type": "string",
+            "pattern": "[a-zA-Z0-9]{0, 1}"
+          }
+        },
+        {
+          "weight": 1.0,
+          "type": "null"
+        }
+      ]
+    },
+    "numeric_array": {
+      "type": "one_of",
+      "variants": [
+        {
+          "weight": 1.0,
+          "type": "array",
+          "length": {
+            "type": "number",
+            "range": {
+              "low": 1,
+              "high": 2,
+              "step": 1
+            },
+            "subtype": "u64"
+          },
+          "content": {
+            "type": "number",
+            "range": {},
+            "subtype": "f64"
+          }
+        },
+        {
+          "weight": 1.0,
+          "type": "null"
+        }
+      ]
+    },
+    "real_array": {
+      "type": "one_of",
+      "variants": [
+        {
+          "weight": 1.0,
+          "type": "array",
+          "length": {
+            "type": "number",
+            "range": {
+              "low": 1,
+              "high": 2,
+              "step": 1
+            },
+            "subtype": "u64"
+          },
+          "content": {
+            "type": "number",
+            "range": {},
+            "subtype": "f32"
+          }
+        },
+        {
+          "weight": 1.0,
+          "type": "null"
+        }
+      ]
+    },
+    "smallint_array": {
+      "type": "one_of",
+      "variants": [
+        {
+          "weight": 1.0,
+          "type": "array",
+          "length": {
+            "type": "number",
+            "range": {
+              "low": 1,
+              "high": 2,
+              "step": 1
+            },
+            "subtype": "u64"
+          },
+          "content": {
+            "type": "number",
+            "range": {},
+            "subtype": "i64"
+          }
+        },
+        {
+          "weight": 1.0,
+          "type": "null"
+        }
+      ]
+    },
+    "string_array": {
+      "type": "one_of",
+      "variants": [
+        {
+          "weight": 1.0,
+          "type": "array",
+          "length": {
+            "type": "number",
+            "range": {
+              "low": 1,
+              "high": 2,
+              "step": 1
+            },
+            "subtype": "u64"
+          },
+          "content": {
+            "type": "string",
+            "pattern": "[a-zA-Z0-9]{0, 1}"
+          }
+        },
+        {
+          "weight": 1.0,
+          "type": "null"
+        }
+      ]
+    },
+    "time_array": {
+      "type": "one_of",
+      "variants": [
+        {
+          "weight": 1.0,
+          "type": "array",
+          "length": {
+            "type": "number",
+            "range": {
+              "low": 1,
+              "high": 2,
+              "step": 1
+            },
+            "subtype": "u64"
+          },
+          "content": {
+            "type": "date_time",
+            "format": "%H:%M:%S",
+            "subtype": "naive_time"
+          }
+        },
+        {
+          "weight": 1.0,
+          "type": "null"
+        }
+      ]
+    },
+    "timestamp_array": {
+      "type": "one_of",
+      "variants": [
+        {
+          "weight": 1.0,
+          "type": "array",
+          "length": {
+            "type": "number",
+            "range": {
+              "low": 1,
+              "high": 2,
+              "step": 1
+            },
+            "subtype": "u64"
+          },
+          "content": {
+            "type": "date_time",
+            "format": "",
+            "subtype": "naive_date_time"
+          }
+        },
+        {
+          "weight": 1.0,
+          "type": "null"
+        }
+      ]
+    },
+    "timestamptz_array": {
+      "type": "one_of",
+      "variants": [
+        {
+          "weight": 1.0,
+          "type": "array",
+          "length": {
+            "type": "number",
+            "range": {
+              "low": 1,
+              "high": 2,
+              "step": 1
+            },
+            "subtype": "u64"
+          },
+          "content": {
+            "type": "date_time",
+            "format": "",
+            "subtype": "date_time"
+          }
+        },
+        {
+          "weight": 1.0,
+          "type": "null"
+        }
+      ]
+    },
+    "ubigint_array": {
+      "type": "one_of",
+      "variants": [
+        {
+          "weight": 1.0,
+          "type": "array",
+          "length": {
+            "type": "number",
+            "range": {
+              "low": 1,
+              "high": 2,
+              "step": 1
+            },
+            "subtype": "u64"
+          },
+          "content": {
+            "type": "number",
+            "range": {},
+            "subtype": "i64"
+          }
+        },
+        {
+          "weight": 1.0,
+          "type": "null"
+        }
+      ]
+    },
+    "uint_array": {
+      "type": "one_of",
+      "variants": [
+        {
+          "weight": 1.0,
+          "type": "array",
+          "length": {
+            "type": "number",
+            "range": {
+              "low": 1,
+              "high": 2,
+              "step": 1
+            },
+            "subtype": "u64"
+          },
+          "content": {
+            "type": "number",
+            "range": {},
+            "subtype": "i32"
+          }
+        },
+        {
+          "weight": 1.0,
+          "type": "null"
+        }
+      ]
+    },
+    "unumeric_array": {
+      "type": "one_of",
+      "variants": [
+        {
+          "weight": 1.0,
+          "type": "array",
+          "length": {
+            "type": "number",
+            "range": {
+              "low": 1,
+              "high": 2,
+              "step": 1
+            },
+            "subtype": "u64"
+          },
+          "content": {
+            "type": "number",
+            "range": {},
+            "subtype": "f64"
+          }
+        },
+        {
+          "weight": 1.0,
+          "type": "null"
+        }
+      ]
+    },
+    "usmallint_array": {
+      "type": "one_of",
+      "variants": [
+        {
+          "weight": 1.0,
+          "type": "array",
+          "length": {
+            "type": "number",
+            "range": {
+              "low": 1,
+              "high": 2,
+              "step": 1
+            },
+            "subtype": "u64"
+          },
+          "content": {
+            "type": "number",
+            "range": {},
+            "subtype": "i64"
+          }
+        },
+        {
+          "weight": 1.0,
+          "type": "null"
+        }
+      ]
+    },
+    "varchar_array": {
+      "type": "one_of",
+      "variants": [
+        {
+          "weight": 1.0,
+          "type": "array",
+          "length": {
+            "type": "number",
+            "range": {
+              "low": 1,
+              "high": 2,
+              "step": 1
+            },
+            "subtype": "u64"
+          },
+          "content": {
+            "type": "string",
+            "pattern": "[a-zA-Z0-9]{0, 1}"
+          }
+        },
+        {
+          "weight": 1.0,
+          "type": "null"
+        }
+      ]
+    }
+  }
+}

--- a/synth/testing_harness/postgres/arrays_master/arrays.json
+++ b/synth/testing_harness/postgres/arrays_master/arrays.json
@@ -296,7 +296,7 @@
           "content": {
             "type": "number",
             "range": {},
-            "subtype": "i64"
+            "subtype": "i32"
           }
         },
         {
@@ -375,7 +375,7 @@
           },
           "content": {
             "type": "date_time",
-            "format": "",
+            "format": "%Y-%m-%dT%H:%M:%S",
             "subtype": "naive_date_time"
           }
         },
@@ -402,7 +402,7 @@
           },
           "content": {
             "type": "date_time",
-            "format": "",
+            "format": "%Y-%m-%dT%H:%M:%S%z",
             "subtype": "date_time"
           }
         },
@@ -511,7 +511,7 @@
           "content": {
             "type": "number",
             "range": {},
-            "subtype": "i64"
+            "subtype": "i32"
           }
         },
         {

--- a/synth/testing_harness/postgres/arrays_master/arrays.json
+++ b/synth/testing_harness/postgres/arrays_master/arrays.json
@@ -11,176 +11,172 @@
   },
   "content": {
     "type": "object",
-    "bigint_array": {
-      "type": "one_of",
-      "variants": [
-        {
-          "weight": 1.0,
-          "type": "array",
-          "length": {
-            "type": "number",
-            "range": {
-              "low": 1,
-              "high": 9,
-              "step": 1
-            },
-            "subtype": "u64"
-          },
-          "content": {
-            "type": "number",
-            "range": {
-              "low": -31059,
-              "high": 30176
-            },
-            "subtype": "i64"
-          }
+    "boolean_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 9,
+          "step": 1
         },
-        {
-          "weight": 1.0,
-          "type": "null"
-        }
-      ]
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "bool",
+        "frequency": 0.5
+      }
     },
-    "bool_array": {
-      "type": "one_of",
-      "variants": [
-        {
-          "weight": 1.0,
-          "type": "array",
-          "length": {
-            "type": "number",
-            "range": {
-              "low": 1,
-              "high": 9,
-              "step": 1
-            },
-            "subtype": "u64"
-          },
-          "content": {
-            "type": "bool",
-            "frequency": 0.5
-          }
+    "bpchar_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 9,
+          "step": 1
         },
-        {
-          "weight": 1.0,
-          "type": "null"
-        }
-      ]
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "string",
+        "pattern": "[a-zA-Z0-9]{0, 1}"
+      }
     },
     "char_array": {
-      "type": "one_of",
-      "variants": [
-        {
-          "weight": 1.0,
-          "type": "array",
-          "length": {
-            "type": "number",
-            "range": {
-              "low": 1,
-              "high": 9,
-              "step": 1
-            },
-            "subtype": "u64"
-          },
-          "content": {
-            "type": "string",
-            "pattern": "[a-zA-Z0-9]{0, 1}"
-          }
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 9,
+          "step": 1
         },
-        {
-          "weight": 1.0,
-          "type": "null"
-        }
-      ]
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "string",
+        "pattern": "[a-zA-Z0-9]{0, 1}"
+      }
     },
     "date_array": {
-      "type": "one_of",
-      "variants": [
-        {
-          "weight": 1.0,
-          "type": "array",
-          "length": {
-            "type": "number",
-            "range": {
-              "low": 1,
-              "high": 7,
-              "step": 1
-            },
-            "subtype": "u64"
-          },
-          "content": {
-            "type": "date_time",
-            "format": "%Y-%m-%d",
-            "subtype": "naive_date",
-            "begin": "2015-01-02",
-            "end": "2019-12-08"
-          }
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 9,
+          "step": 1
         },
-        {
-          "weight": 1.0,
-          "type": "null"
-        }
-      ]
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "date_time",
+        "format": "%Y-%m-%d",
+        "subtype": "naive_date",
+        "begin": "2015-01-09",
+        "end": "2019-12-27"
+      }
     },
-    "double_precision_array": {
-      "type": "one_of",
-      "variants": [
-        {
-          "weight": 1.0,
-          "type": "array",
-          "length": {
-            "type": "number",
-            "range": {
-              "low": 1,
-              "high": 9,
-              "step": 1
-            },
-            "subtype": "u64"
-          },
-          "content": {
-            "type": "number",
-            "range": {
-              "low": -31782.0,
-              "high": 28982.0
-            },
-            "subtype": "f64"
-          }
+    "float4_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 9,
+          "step": 1
         },
-        {
-          "weight": 1.0,
-          "type": "null"
-        }
-      ]
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "number",
+        "range": {
+          "low": -31572.580078125,
+          "high": 32721.41015625
+        },
+        "subtype": "f32"
+      }
     },
-    "int_array": {
-      "type": "one_of",
-      "variants": [
-        {
-          "weight": 1.0,
-          "type": "array",
-          "length": {
-            "type": "number",
-            "range": {
-              "low": 1,
-              "high": 7,
-              "step": 1
-            },
-            "subtype": "u64"
-          },
-          "content": {
-            "type": "number",
-            "range": {
-              "low": -27025,
-              "high": 31240
-            },
-            "subtype": "i32"
-          }
+    "float8_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 7,
+          "step": 1
         },
-        {
-          "weight": 1.0,
-          "type": "null"
-        }
-      ]
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "number",
+        "range": {
+          "low": -31195.78,
+          "high": 31716.440000000002
+        },
+        "subtype": "f64"
+      }
+    },
+    "int2_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 9,
+          "step": 1
+        },
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "number",
+        "range": {
+          "low": -30856,
+          "high": 32726
+        },
+        "subtype": "i32"
+      }
+    },
+    "int4_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 8,
+          "step": 1
+        },
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "number",
+        "range": {
+          "low": -31911,
+          "high": 31842
+        },
+        "subtype": "i32"
+      }
+    },
+    "int8_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 7,
+          "step": 1
+        },
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "number",
+        "range": {
+          "low": -25394,
+          "high": 32038
+        },
+        "subtype": "i64"
+      }
     },
     "int_array_2d": {
       "type": "one_of",
@@ -210,72 +206,6 @@
       ]
     },
     "json_array": {
-      "type": "one_of",
-      "variants": [
-        {
-          "weight": 1.0,
-          "type": "object"
-        },
-        {
-          "weight": 1.0,
-          "type": "null"
-        },
-        {
-          "weight": 1.0,
-          "type": "array",
-          "length": {
-            "type": "number",
-            "range": {
-              "low": 2,
-              "high": 8,
-              "step": 1
-            },
-            "subtype": "u64"
-          },
-          "content": {
-            "type": "one_of",
-            "variants": [
-              {
-                "weight": 1.0,
-                "type": "object",
-                "scores": {
-                  "type": "array",
-                  "length": {
-                    "type": "number",
-                    "range": {
-                      "low": 5,
-                      "high": 6,
-                      "step": 1
-                    },
-                    "subtype": "u64"
-                  },
-                  "content": {
-                    "type": "one_of",
-                    "variants": [
-                      {
-                        "weight": 1.0,
-                        "type": "number",
-                        "range": {
-                          "low": 0,
-                          "high": 99,
-                          "step": 1
-                        },
-                        "subtype": "u64"
-                      }
-                    ]
-                  }
-                },
-                "username": {
-                  "type": "string",
-                  "pattern": "[a-zA-Z0-9]*"
-                }
-              }
-            ]
-          }
-        }
-      ]
-    },
-    "jsonb_array": {
       "type": "one_of",
       "variants": [
         {
@@ -341,380 +271,276 @@
         }
       ]
     },
-    "name_array": {
+    "jsonb_array": {
       "type": "one_of",
       "variants": [
+        {
+          "weight": 1.0,
+          "type": "object"
+        },
+        {
+          "weight": 1.0,
+          "type": "null"
+        },
         {
           "weight": 1.0,
           "type": "array",
           "length": {
             "type": "number",
             "range": {
-              "low": 1,
-              "high": 8,
+              "low": 2,
+              "high": 9,
               "step": 1
             },
             "subtype": "u64"
           },
           "content": {
-            "type": "string",
-            "pattern": "[a-zA-Z0-9]{0, 1}"
+            "type": "one_of",
+            "variants": [
+              {
+                "weight": 1.0,
+                "type": "object",
+                "scores": {
+                  "type": "array",
+                  "length": {
+                    "type": "number",
+                    "range": {
+                      "low": 5,
+                      "high": 6,
+                      "step": 1
+                    },
+                    "subtype": "u64"
+                  },
+                  "content": {
+                    "type": "one_of",
+                    "variants": [
+                      {
+                        "weight": 1.0,
+                        "type": "number",
+                        "range": {
+                          "low": 0,
+                          "high": 99,
+                          "step": 1
+                        },
+                        "subtype": "u64"
+                      }
+                    ]
+                  }
+                },
+                "username": {
+                  "type": "string",
+                  "pattern": "[a-zA-Z0-9]*"
+                }
+              }
+            ]
           }
-        },
-        {
-          "weight": 1.0,
-          "type": "null"
         }
       ]
+    },
+    "name_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 9,
+          "step": 1
+        },
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "string",
+        "pattern": "[a-zA-Z0-9]{0, 1}"
+      }
     },
     "numeric_array": {
-      "type": "one_of",
-      "variants": [
-        {
-          "weight": 1.0,
-          "type": "array",
-          "length": {
-            "type": "number",
-            "range": {
-              "low": 1,
-              "high": 9,
-              "step": 1
-            },
-            "subtype": "u64"
-          },
-          "content": {
-            "type": "number",
-            "range": {
-              "low": -32371.0,
-              "high": 31915.0
-            },
-            "subtype": "f64"
-          }
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 8,
+          "step": 1
         },
-        {
-          "weight": 1.0,
-          "type": "null"
-        }
-      ]
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "number",
+        "range": {
+          "low": -31762.67,
+          "high": 31443.75
+        },
+        "subtype": "f64"
+      }
     },
-    "real_array": {
-      "type": "one_of",
-      "variants": [
-        {
-          "weight": 1.0,
-          "type": "array",
-          "length": {
-            "type": "number",
-            "range": {
-              "low": 1,
-              "high": 9,
-              "step": 1
-            },
-            "subtype": "u64"
-          },
-          "content": {
-            "type": "number",
-            "range": {
-              "low": -32448.0,
-              "high": 32168.0
-            },
-            "subtype": "f32"
-          }
+    "text_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 8,
+          "step": 1
         },
-        {
-          "weight": 1.0,
-          "type": "null"
-        }
-      ]
-    },
-    "smallint_array": {
-      "type": "one_of",
-      "variants": [
-        {
-          "weight": 1.0,
-          "type": "array",
-          "length": {
-            "type": "number",
-            "range": {
-              "low": 1,
-              "high": 8,
-              "step": 1
-            },
-            "subtype": "u64"
-          },
-          "content": {
-            "type": "number",
-            "range": {
-              "low": -31050,
-              "high": 32734
-            },
-            "subtype": "i32"
-          }
-        },
-        {
-          "weight": 1.0,
-          "type": "null"
-        }
-      ]
-    },
-    "string_array": {
-      "type": "one_of",
-      "variants": [
-        {
-          "weight": 1.0,
-          "type": "array",
-          "length": {
-            "type": "number",
-            "range": {
-              "low": 1,
-              "high": 9,
-              "step": 1
-            },
-            "subtype": "u64"
-          },
-          "content": {
-            "type": "string",
-            "pattern": "[a-zA-Z0-9]{0, 1}"
-          }
-        },
-        {
-          "weight": 1.0,
-          "type": "null"
-        }
-      ]
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "string",
+        "pattern": "[a-zA-Z0-9]{0, 1}"
+      }
     },
     "time_array": {
-      "type": "one_of",
-      "variants": [
-        {
-          "weight": 1.0,
-          "type": "array",
-          "length": {
-            "type": "number",
-            "range": {
-              "low": 1,
-              "high": 8,
-              "step": 1
-            },
-            "subtype": "u64"
-          },
-          "content": {
-            "type": "date_time",
-            "format": "%H:%M:%S",
-            "subtype": "naive_time",
-            "begin": "00:11:49",
-            "end": "22:59:22"
-          }
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 9,
+          "step": 1
         },
-        {
-          "weight": 1.0,
-          "type": "null"
-        }
-      ]
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "date_time",
+        "format": "%H:%M:%S",
+        "subtype": "naive_time",
+        "begin": "00:37:03",
+        "end": "22:29:41"
+      }
     },
     "timestamp_array": {
-      "type": "one_of",
-      "variants": [
-        {
-          "weight": 1.0,
-          "type": "array",
-          "length": {
-            "type": "number",
-            "range": {
-              "low": 1,
-              "high": 9,
-              "step": 1
-            },
-            "subtype": "u64"
-          },
-          "content": {
-            "type": "date_time",
-            "format": "%Y-%m-%dT%H:%M:%S",
-            "subtype": "naive_date_time",
-            "begin": "2015-01-01T03:04:18",
-            "end": "2019-12-16T02:02:24"
-          }
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 8,
+          "step": 1
         },
-        {
-          "weight": 1.0,
-          "type": "null"
-        }
-      ]
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "date_time",
+        "format": "%Y-%m-%dT%H:%M:%S",
+        "subtype": "naive_date_time",
+        "begin": "2015-02-14T16:41:01",
+        "end": "2019-10-06T23:46:18"
+      }
     },
     "timestamptz_array": {
-      "type": "one_of",
-      "variants": [
-        {
-          "weight": 1.0,
-          "type": "array",
-          "length": {
-            "type": "number",
-            "range": {
-              "low": 1,
-              "high": 9,
-              "step": 1
-            },
-            "subtype": "u64"
-          },
-          "content": {
-            "type": "date_time",
-            "format": "%Y-%m-%dT%H:%M:%S%z",
-            "subtype": "date_time",
-            "begin": "2015-02-13T10:58:51+0000",
-            "end": "2019-12-24T00:22:16+0000"
-          }
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 8,
+          "step": 1
         },
-        {
-          "weight": 1.0,
-          "type": "null"
-        }
-      ]
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "date_time",
+        "format": "%Y-%m-%dT%H:%M:%S%z",
+        "subtype": "date_time",
+        "begin": "2015-01-20T01:00:41+0000",
+        "end": "2019-10-28T09:37:36+0000"
+      }
     },
-    "ubigint_array": {
-      "type": "one_of",
-      "variants": [
-        {
-          "weight": 1.0,
-          "type": "array",
-          "length": {
-            "type": "number",
-            "range": {
-              "low": 1,
-              "high": 9,
-              "step": 1
-            },
-            "subtype": "u64"
-          },
-          "content": {
-            "type": "number",
-            "range": {
-              "low": 176,
-              "high": 32112
-            },
-            "subtype": "i64"
-          }
+    "uint2_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 9,
+          "step": 1
         },
-        {
-          "weight": 1.0,
-          "type": "null"
-        }
-      ]
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "number",
+        "range": {
+          "low": 341,
+          "high": 32588
+        },
+        "subtype": "i32"
+      }
     },
-    "uint_array": {
-      "type": "one_of",
-      "variants": [
-        {
-          "weight": 1.0,
-          "type": "array",
-          "length": {
-            "type": "number",
-            "range": {
-              "low": 1,
-              "high": 8,
-              "step": 1
-            },
-            "subtype": "u64"
-          },
-          "content": {
-            "type": "number",
-            "range": {
-              "low": 901,
-              "high": 32145
-            },
-            "subtype": "i32"
-          }
+    "uint4_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 9,
+          "step": 1
         },
-        {
-          "weight": 1.0,
-          "type": "null"
-        }
-      ]
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "number",
+        "range": {
+          "low": 280,
+          "high": 32750
+        },
+        "subtype": "i32"
+      }
+    },
+    "uint8_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 8,
+          "step": 1
+        },
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "number",
+        "range": {
+          "low": 258,
+          "high": 31382
+        },
+        "subtype": "i64"
+      }
     },
     "unumeric_array": {
-      "type": "one_of",
-      "variants": [
-        {
-          "weight": 1.0,
-          "type": "array",
-          "length": {
-            "type": "number",
-            "range": {
-              "low": 1,
-              "high": 8,
-              "step": 1
-            },
-            "subtype": "u64"
-          },
-          "content": {
-            "type": "number",
-            "range": {
-              "low": 1152.0,
-              "high": 32038.0
-            },
-            "subtype": "f64"
-          }
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 9,
+          "step": 1
         },
-        {
-          "weight": 1.0,
-          "type": "null"
-        }
-      ]
-    },
-    "usmallint_array": {
-      "type": "one_of",
-      "variants": [
-        {
-          "weight": 1.0,
-          "type": "array",
-          "length": {
-            "type": "number",
-            "range": {
-              "low": 1,
-              "high": 9,
-              "step": 1
-            },
-            "subtype": "u64"
-          },
-          "content": {
-            "type": "number",
-            "range": {
-              "low": 596,
-              "high": 32691
-            },
-            "subtype": "i32"
-          }
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "number",
+        "range": {
+          "low": 420.14,
+          "high": 31531.13
         },
-        {
-          "weight": 1.0,
-          "type": "null"
-        }
-      ]
+        "subtype": "f64"
+      }
     },
     "varchar_array": {
-      "type": "one_of",
-      "variants": [
-        {
-          "weight": 1.0,
-          "type": "array",
-          "length": {
-            "type": "number",
-            "range": {
-              "low": 1,
-              "high": 9,
-              "step": 1
-            },
-            "subtype": "u64"
-          },
-          "content": {
-            "type": "string",
-            "pattern": "[a-zA-Z0-9]{0, 1}"
-          }
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 9,
+          "step": 1
         },
-        {
-          "weight": 1.0,
-          "type": "null"
-        }
-      ]
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "string",
+        "pattern": "[a-zA-Z0-9]{0, 1}"
+      }
     }
   }
 }

--- a/synth/testing_harness/postgres/arrays_master/arrays.json
+++ b/synth/testing_harness/postgres/arrays_master/arrays.json
@@ -209,6 +209,138 @@
         }
       ]
     },
+    "json_array": {
+      "type": "one_of",
+      "variants": [
+        {
+          "weight": 1.0,
+          "type": "object"
+        },
+        {
+          "weight": 1.0,
+          "type": "null"
+        },
+        {
+          "weight": 1.0,
+          "type": "array",
+          "length": {
+            "type": "number",
+            "range": {
+              "low": 2,
+              "high": 8,
+              "step": 1
+            },
+            "subtype": "u64"
+          },
+          "content": {
+            "type": "one_of",
+            "variants": [
+              {
+                "weight": 1.0,
+                "type": "object",
+                "scores": {
+                  "type": "array",
+                  "length": {
+                    "type": "number",
+                    "range": {
+                      "low": 5,
+                      "high": 6,
+                      "step": 1
+                    },
+                    "subtype": "u64"
+                  },
+                  "content": {
+                    "type": "one_of",
+                    "variants": [
+                      {
+                        "weight": 1.0,
+                        "type": "number",
+                        "range": {
+                          "low": 0,
+                          "high": 99,
+                          "step": 1
+                        },
+                        "subtype": "u64"
+                      }
+                    ]
+                  }
+                },
+                "username": {
+                  "type": "string",
+                  "pattern": "[a-zA-Z0-9]*"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "jsonb_array": {
+      "type": "one_of",
+      "variants": [
+        {
+          "weight": 1.0,
+          "type": "object"
+        },
+        {
+          "weight": 1.0,
+          "type": "null"
+        },
+        {
+          "weight": 1.0,
+          "type": "array",
+          "length": {
+            "type": "number",
+            "range": {
+              "low": 1,
+              "high": 10,
+              "step": 1
+            },
+            "subtype": "u64"
+          },
+          "content": {
+            "type": "one_of",
+            "variants": [
+              {
+                "weight": 1.0,
+                "type": "object",
+                "scores": {
+                  "type": "array",
+                  "length": {
+                    "type": "number",
+                    "range": {
+                      "low": 5,
+                      "high": 6,
+                      "step": 1
+                    },
+                    "subtype": "u64"
+                  },
+                  "content": {
+                    "type": "one_of",
+                    "variants": [
+                      {
+                        "weight": 1.0,
+                        "type": "number",
+                        "range": {
+                          "low": 0,
+                          "high": 99,
+                          "step": 1
+                        },
+                        "subtype": "u64"
+                      }
+                    ]
+                  }
+                },
+                "username": {
+                  "type": "string",
+                  "pattern": "[a-zA-Z0-9]*"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
     "name_array": {
       "type": "one_of",
       "variants": [

--- a/synth/testing_harness/postgres/arrays_master/unofficial_arrays.json
+++ b/synth/testing_harness/postgres/arrays_master/unofficial_arrays.json
@@ -1,0 +1,302 @@
+{
+  "type": "array",
+  "length": {
+    "type": "number",
+    "range": {
+      "low": 1,
+      "high": 10,
+      "step": 1
+    },
+    "subtype": "u64"
+  },
+  "content": {
+    "type": "object",
+    "bigint_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 9,
+          "step": 1
+        },
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "number",
+        "range": {
+          "low": -32362,
+          "high": 31882
+        },
+        "subtype": "i64"
+      }
+    },
+    "bool_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 9,
+          "step": 1
+        },
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "bool",
+        "frequency": 0.5
+      }
+    },
+    "character_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 9,
+          "step": 1
+        },
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "string",
+        "pattern": "[a-zA-Z0-9]{0, 1}"
+      }
+    },
+    "character_varying_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 8,
+          "step": 1
+        },
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "string",
+        "pattern": "[a-zA-Z0-9]{0, 1}"
+      }
+    },
+    "decimal_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 9,
+          "step": 1
+        },
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "number",
+        "range": {
+          "low": -29508.77,
+          "high": 32595.16
+        },
+        "subtype": "f64"
+      }
+    },
+    "double_precision_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 9,
+          "step": 1
+        },
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "number",
+        "range": {
+          "low": -32728.93,
+          "high": 30830.96
+        },
+        "subtype": "f64"
+      }
+    },
+    "int_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 8,
+          "step": 1
+        },
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "number",
+        "range": {
+          "low": -31922,
+          "high": 32726
+        },
+        "subtype": "i32"
+      }
+    },
+    "integer_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 9,
+          "step": 1
+        },
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "number",
+        "range": {
+          "low": -31954,
+          "high": 31577
+        },
+        "subtype": "i32"
+      }
+    },
+    "real_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 9,
+          "step": 1
+        },
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "number",
+        "range": {
+          "low": -30618.009765625,
+          "high": 30062.16015625
+        },
+        "subtype": "f32"
+      }
+    },
+    "smallint_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 9,
+          "step": 1
+        },
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "number",
+        "range": {
+          "low": -31803,
+          "high": 31156
+        },
+        "subtype": "i32"
+      }
+    },
+    "timestamp_with_time_zone_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 9,
+          "step": 1
+        },
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "date_time",
+        "format": "%Y-%m-%dT%H:%M:%S%z",
+        "subtype": "date_time",
+        "begin": "2015-01-18T10:24:22+0000",
+        "end": "2019-11-10T12:31:48+0000"
+      }
+    },
+    "ubigint_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 9,
+          "step": 1
+        },
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "number",
+        "range": {
+          "low": 934,
+          "high": 32630
+        },
+        "subtype": "i64"
+      }
+    },
+    "uint_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 9,
+          "step": 1
+        },
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "number",
+        "range": {
+          "low": 2034,
+          "high": 32596
+        },
+        "subtype": "i32"
+      }
+    },
+    "uinteger_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 9,
+          "step": 1
+        },
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "number",
+        "range": {
+          "low": 965,
+          "high": 32446
+        },
+        "subtype": "i32"
+      }
+    },
+    "usmallint_array": {
+      "type": "array",
+      "length": {
+        "type": "number",
+        "range": {
+          "low": 1,
+          "high": 9,
+          "step": 1
+        },
+        "subtype": "u64"
+      },
+      "content": {
+        "type": "number",
+        "range": {
+          "low": 531,
+          "high": 32717
+        },
+        "subtype": "i32"
+      }
+    }
+  }
+}

--- a/synth/testing_harness/postgres/complete_import_master/types.json
+++ b/synth/testing_harness/postgres/complete_import_master/types.json
@@ -92,7 +92,7 @@
         {
           "type": "date_time",
           "subtype": "date_time",
-          "format": "",
+          "format": "%Y-%m-%dT%H:%M:%S%z",
           "weight": 1
         },
         {
@@ -107,7 +107,7 @@
         {
           "type": "date_time",
           "subtype": "naive_date_time",
-          "format": "",
+          "format": "%Y-%m-%dT%H:%M:%S",
           "weight": 1
         },
         {

--- a/synth/testing_harness/postgres/complete_import_master/unofficial_types.json
+++ b/synth/testing_harness/postgres/complete_import_master/unofficial_types.json
@@ -69,7 +69,7 @@
         {
           "type": "date_time",
           "subtype": "date_time",
-          "format": "",
+          "format": "%Y-%m-%dT%H:%M:%S%z",
           "weight": 1
         },
         {
@@ -80,7 +80,7 @@
     },
     "id_serial2": {
       "type": "number",
-      "subtype": "i64",
+      "subtype": "i32",
       "range": {
         "low": 1,
         "high": 10
@@ -88,7 +88,7 @@
     },
     "id_smallserial": {
       "type": "number",
-      "subtype": "i64",
+      "subtype": "i32",
       "range": {
         "low": 1,
         "high": 10

--- a/synth/testing_harness/postgres/e2e.sh
+++ b/synth/testing_harness/postgres/e2e.sh
@@ -100,7 +100,7 @@ function test-arrays() {
   if [ ! -z "$ERRORS" ]
   then
     echo -e "${ERROR}Did not expect errors:${NC}"
-    echo $ERRORS
+    echo -e $ERRORS
     return 1
   fi
 

--- a/synth/testing_harness/postgres/e2e.sh
+++ b/synth/testing_harness/postgres/e2e.sh
@@ -27,6 +27,7 @@ commands:
   test-import|Test importing from postgres data
   test-complete|Test generating and importing all types to/from postgres
   test-warning|Test integer warnings
+  test-arrays|Test encoding array values
   test-local|Run all test on a local machine using the container from 'up' (no need to call 'up' first)
   up|Starts a local Docker instance for testing
   down|Stops container started with 'up'
@@ -91,6 +92,18 @@ function test-warning() {
   fi
 }
 
+function test-arrays() {
+  echo -e "${INFO}Testing arrays to postgres${NC}"
+  psql -f arrays/0_arrays.sql postgres://postgres:$PASSWORD@localhost:$PORT/postgres
+  ERRORS=$($SYNTH generate --to postgres://postgres:$PASSWORD@localhost:$PORT/postgres arrays 2>&1)
+  if [ ! -z "$ERRORS" ]
+  then
+    echo -e "${ERROR}Did not expect errors:${NC}"
+    echo $ERRORS
+    return 1
+  fi
+}
+
 function test-local() {
   up || return 1
 
@@ -99,6 +112,7 @@ function test-local() {
   test-import || result=$?
   test-complete || result=$?
   test-warning || result=$?
+  test-arrays || result=$?
 
   down
   cleanup
@@ -152,6 +166,9 @@ case "${1-*}" in
     ;;
   test-warning)
     test-warning || exit 1
+    ;;
+  test-arrays)
+    test-arrays || exit 1
     ;;
   test-local)
     test-local || exit 1

--- a/synth/testing_harness/postgres/e2e.sh
+++ b/synth/testing_harness/postgres/e2e.sh
@@ -105,7 +105,6 @@ function test-arrays() {
   fi
 
   echo -e "${INFO}Testing importing postgres arrays${NC}"
-  psql -c "ALTER TABLE arrays DROP COLUMN json_array, DROP COLUMN jsonb_array;" postgres://postgres:$PASSWORD@localhost:$PORT/arrays
   $SYNTH import --from postgres://postgres:${PASSWORD}@localhost:${PORT}/arrays arrays_import || { echo -e "${ERROR}Array import failed${NC}"; return 1; }
   diff <(jq --sort-keys . arrays_import/*) <(jq --sort-keys . arrays_master/*) || { echo -e "${ERROR}Import arrays do not match${NC}"; return 1; }
 }

--- a/synth/testing_harness/postgres/e2e.sh
+++ b/synth/testing_harness/postgres/e2e.sh
@@ -96,11 +96,11 @@ function test-arrays() {
   echo -e "${INFO}Testing arrays to postgres${NC}"
   psql -c "CREATE DATABASE arrays;" postgres://postgres:$PASSWORD@localhost:$PORT/postgres
   psql -f arrays/0_arrays.sql postgres://postgres:$PASSWORD@localhost:$PORT/arrays
-  ERRORS=$($SYNTH generate --to postgres://postgres:$PASSWORD@localhost:$PORT/arrays arrays 2>&1)
-  if [ ! -z "$ERRORS" ]
+  errors=$($SYNTH generate --to postgres://postgres:$PASSWORD@localhost:$PORT/arrays arrays 2>&1)
+  if [ ! -z "$errors" ]
   then
     echo -e "${ERROR}Did not expect errors:${NC}"
-    echo -e $ERRORS
+    echo -e $errors
     return 1
   fi
 

--- a/synth/testing_harness/postgres/hospital_master/hospitals.json
+++ b/synth/testing_harness/postgres/hospital_master/hospitals.json
@@ -43,6 +43,32 @@
       "type": "number",
       "id": {},
       "subtype": "i32"
+    },
+    "specialities": {
+      "type": "one_of",
+      "variants": [
+        {
+          "weight": 1.0,
+          "type": "array",
+          "length": {
+            "type": "number",
+            "range": {
+              "low": 1,
+              "high": 2,
+              "step": 1
+            },
+            "subtype": "u64"
+          },
+          "content": {
+            "type": "string",
+            "pattern": "[a-zA-Z0-9]{0, 1}"
+          }
+        },
+        {
+          "weight": 1.0,
+          "type": "null"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Allows generating and importing postgres arrays to close #171. Also covers array of json generation and json importing to close #67.

### Things that don't work
- Generating array of Uuids: uuids end up as `Value::String` which cause them to be `text` [here](https://github.com/getsynth/synth/pull/233/files#diff-d9f8a38de3635edbbe1088a44805d801aee9b6c34f91199cc80777016faa1283R282). Adding a `Value::Uuid` type should fix this, I will just need guidance about how please :smile: 
- Generating empty arrays don't work since they cannot be identified [here](https://github.com/getsynth/synth/pull/233/files#diff-d9f8a38de3635edbbe1088a44805d801aee9b6c34f91199cc80777016faa1283R293). But generating an array with min length of 1 as a `one_of` null does work.
- Generating the postgres array of json type (`json[]`) does not work. Instead just using the simple postgres `json` type with an array in it (`{[]}`) does work - [schema](https://github.com/getsynth/synth/pull/233/files#diff-ce91d5004fe1fb8734c55cb16557a81d10f62a67731ac5c410f6be8bff77d720R25) and [generation definition](https://github.com/getsynth/synth/pull/233/files#diff-15ead1943d9c7a4bb6e82cbbaefd9516a0011c35f129637be6e74545ec55ac81R386-R418)