### PR TITLE
feat: implement CSV import/export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,6 +535,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,6 +821,28 @@ checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
 dependencies = [
  "generic-array",
  "subtle",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2496,6 +2530,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3185,6 +3225,7 @@ dependencies = [
  "chrono",
  "colored",
  "console",
+ "csv",
  "ctrlc",
  "dirs",
  "env_logger",

--- a/docs/docs/getting_started/cli.md
+++ b/docs/docs/getting_started/cli.md
@@ -26,13 +26,15 @@ If a subdirectory for a given namespace does not exist, Synth will create it.
 
 - `--from <uri>` - The location from which to import. Synth uses Uniform Resource Identifiers (URIs) to define interactions with databases and the filesystem. `<uri>` must therefore be a valid RFC 3986 URI.
 
-  It is possible to import from a file using the URI schemes `json:` and `jsonl:` depending of course on whether the data specified is encoded as JSON or JSON Lines respectively. For example, one could import data from a file `data.jsonl` in the current working directory by specifying `jsonl:data.json`. Note the lack of `//` that you may be used to seeing - this can be omitted as this URI will never have an authority component (unlike, for example, a database URI).
-
-  Data can be imported from standard input by simply not specifying a path in the URI (e.g. `json:` will read JSON data from standard input while `jsonl:` will read JSON Lines data). If no `--from` argument is specified, JSON data will read from standard input by default.
-
   Importing from a database is possible using the standard URI format of the respective database. For example: `postgres://user:pass@localhost:5432/tpch`
 
+  It is possible to import from a file using the URI schemes `json:`, `jsonl:`, `csv:` depending on whether the data specified is encoded as JSON, JSON Lines or CSV respectively. For example, one could import data from a file `data.jsonl` in the current working directory by specifying `jsonl:data.json`. Note the lack of `//` that you may be used to seeing - this can be omitted as this URI will never have an authority component (unlike, for example, a database URI).
+
+  Data can be imported from standard input by simply not specifying a path in the URI (e.g. `jsonl:` will read JSON Lines data directly from standard input). If no `--from` argument is specified, JSON data will read from standard input by default.
+
   When dealing with JSON Lines and not specifying a single collection with the `--collection` argument, each generated object is tagged with the name of the collection it was generated from. By default, this is done by adding a property `type` to the object (e.g. `"type": "collection_name"`). The name of this property can be changed using an additional parameter `collection_field_name` added at the end of the URI like so: `jsonl:file.jsonl?collection_field_name=foobar` - with this URI used with `--from`, generate objects will instead have a property like `"foobar": "collection_name"`.
+
+  With regards to CSV importing/exporting, it is important to note that the URI path should specify a directory and not an individual file. This is because, unlike JSON and JSON Lines, a single CSV file cannot easily represent data from multiple collections so each collection's data is stored in a separate `.csv` file. Also, when importing CSV, Synth by default assumes that the input data will contain a header row, unless a `?header_row=false` argument is present at the end of the URI.
 
 ---
 

--- a/synth/Cargo.toml
+++ b/synth/Cargo.toml
@@ -79,3 +79,5 @@ semver = "1.0.4"
 
 uriparse = "0.6.3"
 querystring = "1.1.0"
+
+csv = "1.1.6"

--- a/synth/src/cli/csv/headers.rs
+++ b/synth/src/cli/csv/headers.rs
@@ -1,0 +1,415 @@
+use synth_core::schema::content::{ArrayContent, ObjectContent, SameAsContent};
+use synth_core::{Content, Namespace};
+
+use super::determine_content_array_max_length;
+
+use std::fmt;
+
+use anyhow::Result;
+
+use regex::Regex;
+
+pub struct CsvHeaders(Vec<CsvHeader>);
+
+impl CsvHeaders {
+    /// Flattern a `Content` instance into a set of CSV headers. The `content` parameter should correspond to the inner
+    /// content value inside of the outer most array generator in a schema.
+    pub fn from_content(content: &Content, namespace: &Namespace) -> Result<Self> {
+        match content {
+            Content::Object(obj) => parse_object_to_headers(None, obj, namespace),
+            Content::Array(array) => parse_array_to_headers(None, array, namespace),
+            Content::OneOf(_) => parse_one_of_to_headers(
+                CsvHeader::ObjectProperty {
+                    key: "one_of".to_string(),
+                    parent: None,
+                },
+                content,
+                namespace,
+            ),
+            Content::SameAs(same_as) => parse_same_as_to_headers(
+                CsvHeader::ObjectProperty {
+                    key: "same_as".to_string(),
+                    parent: None,
+                },
+                same_as,
+                namespace,
+            ),
+            Content::Unique(unique) => parse_content_to_headers(
+                CsvHeader::ObjectProperty {
+                    key: "unique".to_string(),
+                    parent: None,
+                },
+                &unique.content,
+                namespace,
+            ),
+            _ => Ok(vec![CsvHeader::ObjectProperty {
+                key: "value".to_string(),
+                parent: None,
+            }]),
+        }
+        .map(CsvHeaders)
+    }
+
+    pub fn from_csv_header_record(record: &csv::StringRecord) -> Result<Self> {
+        record
+            .into_iter()
+            .map(CsvHeader::from_csv_str)
+            .collect::<Result<Vec<CsvHeader>>>()
+            .map(CsvHeaders)
+    }
+
+    pub fn to_csv_record(&self) -> csv::StringRecord {
+        csv::StringRecord::from(
+            self.0
+                .iter()
+                .map(CsvHeader::to_string)
+                .collect::<Vec<String>>(),
+        )
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &CsvHeader> {
+        self.0.iter()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum CsvHeader {
+    ArrayElement {
+        parent: Option<Box<CsvHeader>>,
+        index: usize,
+        max_length: usize,
+    },
+    ObjectProperty {
+        parent: Option<Box<CsvHeader>>,
+        key: String,
+    },
+}
+
+lazy_static::lazy_static! {
+    static ref ARRAY_INDEX_REGEX: Regex = Regex::new(r"\A\[([0-9]+)\]").unwrap();
+}
+
+impl CsvHeader {
+    fn from_csv_str(s: &str) -> Result<Self> {
+        let mut s_index = 0;
+        let mut header = None;
+
+        while s_index < s.len() {
+            let substr = &s[s_index..];
+            let search = ARRAY_INDEX_REGEX.find(substr);
+
+            header = if let Some(found) = search {
+                let found_str = found.as_str();
+
+                s_index += found_str.len();
+
+                let index = found_str[1..found_str.len() - 1].parse().unwrap();
+
+                Some(CsvHeader::ArrayElement {
+                    parent: header.map(Box::new),
+                    index,
+                    max_length: 0,
+                })
+            } else {
+                let find_index = substr
+                    .find(|c| c == '.' || c == '[')
+                    .unwrap_or(substr.len());
+
+                let key = &substr[..find_index];
+
+                if key.is_empty() {
+                    return Err(anyhow!(
+                        "Invalid CSV header '{}' - cannot have an empty object property name.",
+                        s
+                    ));
+                }
+
+                s_index += key.len();
+
+                Some(CsvHeader::ObjectProperty {
+                    parent: header.map(Box::new),
+                    key: key.to_string(),
+                })
+            };
+
+            if s[s_index..].starts_with('.') {
+                s_index += 1;
+            } else if !s[s_index..].starts_with('[') && !s[s_index..].is_empty() {
+                return Err(anyhow!("Invalid CSV header '{}' - expected '.' or '['.", s));
+            }
+        }
+
+        header.ok_or_else(|| anyhow!("Values in header row cannot be empty."))
+    }
+
+    pub fn components_from_parent_to_child(&self) -> Vec<&CsvHeader> {
+        let mut components = Vec::new();
+
+        let mut current = self;
+
+        while !matches!(
+            current,
+            CsvHeader::ObjectProperty { parent: None, .. }
+                | CsvHeader::ArrayElement { parent: None, .. }
+        ) {
+            components.insert(0, current);
+            match current {
+                CsvHeader::ArrayElement { parent, .. }
+                | CsvHeader::ObjectProperty { parent, .. } => current = &*parent.as_ref().unwrap(),
+            }
+        }
+        components.insert(0, current);
+
+        components
+    }
+}
+
+impl fmt::Display for CsvHeader {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::ArrayElement {
+                parent: Some(parent),
+                index,
+                ..
+            } => write!(f, "{}[{}]", parent, index),
+            Self::ArrayElement {
+                parent: None,
+                index,
+                ..
+            } => write!(f, "[{}]", index),
+            Self::ObjectProperty {
+                parent: Some(parent),
+                key,
+            } => write!(f, "{}.{}", parent, key),
+            Self::ObjectProperty { parent: None, key } => write!(f, "{}", key),
+        }
+    }
+}
+
+/// Recursively parses nested `Content` into a set of CSV headers.
+fn parse_content_to_headers(
+    parent: CsvHeader,
+    content: &Content,
+    namespace: &Namespace,
+) -> Result<Vec<CsvHeader>> {
+    match content {
+        Content::Object(obj) => parse_object_to_headers(Some(&parent), obj, namespace),
+        Content::Array(array) => parse_array_to_headers(Some(&parent), array, namespace),
+        Content::OneOf(_) => parse_one_of_to_headers(parent, content, namespace),
+        Content::SameAs(same_as) => parse_same_as_to_headers(parent, same_as, namespace),
+        Content::Unique(unique) => parse_content_to_headers(parent, &unique.content, namespace),
+        _ => Ok(vec![parent]),
+    }
+}
+
+fn parse_object_to_headers(
+    parent: Option<&CsvHeader>,
+    obj: &ObjectContent,
+    ns: &Namespace,
+) -> Result<Vec<CsvHeader>> {
+    let mut flatterned = Vec::new();
+
+    for (field_name, field_content) in &obj.fields {
+        flatterned.extend(parse_content_to_headers(
+            CsvHeader::ObjectProperty {
+                parent: parent.cloned().map(Box::new),
+                key: field_name.clone(),
+            },
+            field_content,
+            ns,
+        )?);
+    }
+
+    Ok(flatterned)
+}
+
+fn parse_array_to_headers(
+    parent: Option<&CsvHeader>,
+    array: &ArrayContent,
+    ns: &Namespace,
+) -> Result<Vec<CsvHeader>> {
+    let max_length = determine_content_array_max_length(array);
+
+    let mut headers = Vec::new();
+
+    for index in 0..max_length {
+        headers.extend(
+            parse_content_to_headers(
+                CsvHeader::ArrayElement {
+                    parent: parent.cloned().map(Box::new),
+                    index,
+                    max_length,
+                },
+                &array.content,
+                ns,
+            )?
+            .into_iter(),
+        );
+    }
+
+    Ok(headers)
+}
+
+fn parse_same_as_to_headers(
+    parent: CsvHeader,
+    same_as: &SameAsContent,
+    ns: &Namespace,
+) -> Result<Vec<CsvHeader>> {
+    // Should be safe to unwrap as references have already been checked.
+    let same_as_node = ns.get_s_node(&same_as.ref_).unwrap();
+    parse_content_to_headers(parent, same_as_node, ns)
+}
+
+fn parse_one_of_to_headers(
+    parent: CsvHeader,
+    content: &Content,
+    ns: &Namespace,
+) -> Result<Vec<CsvHeader>> {
+    if !content.is_scalar(ns)? {
+        return Err(anyhow::anyhow!(
+            "All variants in a 'one_of' generator must be scalar when exporting to CSV"
+        ));
+    }
+    Ok(vec![parent])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use synth_core::schema::{
+        number_content, BoolContent, FieldRef, NullContent, NumberContent, OneOfContent, RangeStep,
+        SameAsContent, VariantContent,
+    };
+
+    use std::collections::BTreeMap;
+
+    fn assert_csv_header_str_conversion(s: &str) {
+        assert_eq!(&CsvHeader::from_csv_str(s).unwrap().to_string(), s);
+    }
+
+    #[test]
+    fn test_csv_header_from_csv_str() {
+        for s in &["abc", "abc.def", "a.b.c", "a[0]", "[1][2][3]", "a[12].x"] {
+            assert_csv_header_str_conversion(s);
+        }
+
+        for s in &["", "a..b", "a[1]x"] {
+            assert!(CsvHeader::from_csv_str(s).is_err());
+        }
+    }
+
+    #[test]
+    fn test_components_from_parent_to_child() {
+        let root = CsvHeader::ObjectProperty {
+            key: "root".to_string(),
+            parent: None,
+        };
+        let middle = CsvHeader::ObjectProperty {
+            parent: Some(Box::new(root.clone())),
+            key: "x".to_string(),
+        };
+        let child = CsvHeader::ArrayElement {
+            parent: Some(Box::new(middle.clone())),
+            index: 0,
+            max_length: 1,
+        };
+
+        assert_eq!(
+            child.components_from_parent_to_child(),
+            vec![&root, &middle, &child],
+        );
+    }
+
+    #[test]
+    fn test_content_to_csv_header_record() {
+        let content = Content::Object(ObjectContent {
+            fields: {
+                let mut m = BTreeMap::new();
+
+                m.insert(
+                    "w".to_string(),
+                    Content::Object(ObjectContent {
+                        fields: {
+                            let mut w = BTreeMap::new();
+                            w.insert(
+                                "a".to_string(),
+                                Content::Object(ObjectContent {
+                                    fields: {
+                                        let mut a = BTreeMap::new();
+                                        a.insert(
+                                            "b".to_string(),
+                                            Content::Bool(BoolContent::Constant(false)),
+                                        );
+                                        a
+                                    },
+                                    ..Default::default()
+                                }),
+                            );
+                            w
+                        },
+                        ..Default::default()
+                    }),
+                );
+
+                m.insert(
+                    "x".to_string(),
+                    Content::Array(ArrayContent {
+                        length: Box::new(Content::Number(NumberContent::U64(
+                            number_content::U64::Constant(2),
+                        ))),
+                        content: Box::new(Content::Array(ArrayContent {
+                            length: Box::new(Content::Number(NumberContent::U64(
+                                number_content::U64::Range(RangeStep {
+                                    low: Some(1),
+                                    high: Some(4),
+                                    step: Some(1),
+                                    ..Default::default()
+                                }),
+                            ))),
+                            content: Box::new(Content::Null(NullContent)),
+                        })),
+                    }),
+                );
+
+                m.insert(
+                    "y".to_string(),
+                    Content::OneOf(OneOfContent {
+                        variants: vec![
+                            VariantContent::new(Content::Null(NullContent)),
+                            VariantContent::new(Content::SameAs(SameAsContent {
+                                ref_: FieldRef::new("my_collection.z").unwrap(),
+                            })),
+                        ],
+                    }),
+                );
+
+                m.insert("z".to_string(), Content::Bool(BoolContent::Constant(true)));
+
+                m
+            },
+            ..Default::default()
+        });
+
+        let mut namespace = Namespace::new();
+        namespace
+            .put_collection("my_collection".to_string(), content.clone())
+            .unwrap();
+
+        assert_eq!(
+            CsvHeaders::from_content(&content, &namespace)
+                .unwrap()
+                .to_csv_record(),
+            csv::StringRecord::from(vec![
+                "w.a.b".to_string(),
+                "x[0][0]".to_string(),
+                "x[0][1]".to_string(),
+                "x[0][2]".to_string(),
+                "x[1][0]".to_string(),
+                "x[1][1]".to_string(),
+                "x[1][2]".to_string(),
+                "y".to_string(),
+                "z".to_string(),
+            ])
+        );
+    }
+}

--- a/synth/src/cli/csv/mod.rs
+++ b/synth/src/cli/csv/mod.rs
@@ -1,0 +1,554 @@
+mod headers;
+
+use crate::cli::export::{ExportParams, ExportStrategy};
+use crate::sampler::{Sampler, SamplerOutput};
+
+use synth_core::schema::content::{number_content, ArrayContent, NumberContent};
+use synth_core::schema::{MergeStrategy, OptionalMergeStrategy};
+use synth_core::{Content, Namespace, Value};
+use synth_gen::value::Number;
+
+use anyhow::Result;
+
+use std::convert::TryFrom;
+use std::path::PathBuf;
+
+use super::import::ImportStrategy;
+
+#[derive(Clone, Debug)]
+pub struct CsvFileExportStrategy {
+    pub to_dir: PathBuf,
+}
+
+impl ExportStrategy for CsvFileExportStrategy {
+    fn export(&self, params: ExportParams) -> Result<SamplerOutput> {
+        let generator = Sampler::try_from(&params.namespace)?;
+        let output = generator.sample_seeded(params.collection_name, params.target, params.seed)?;
+
+        if self.to_dir.exists() {
+            return Err(anyhow::anyhow!("Output directory already exists"));
+        } else {
+            std::fs::create_dir_all(&self.to_dir)?;
+        }
+
+        match csv_output_from_sampler_ouput(output.clone(), &params.namespace)? {
+            CsvOutput::Namespace(ns) => {
+                for (name, csv) in ns {
+                    std::fs::write(self.to_dir.join(name + ".csv"), csv)?;
+                }
+            }
+            CsvOutput::SingleCollection(csv) => {
+                std::fs::write(self.to_dir.join("collection.csv"), csv)?;
+            }
+        }
+
+        Ok(output)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CsvStdoutExportStrategy;
+
+impl ExportStrategy for CsvStdoutExportStrategy {
+    fn export(&self, params: ExportParams) -> Result<SamplerOutput> {
+        let generator = Sampler::try_from(&params.namespace)?;
+        let output = generator.sample_seeded(params.collection_name, params.target, params.seed)?;
+
+        match csv_output_from_sampler_ouput(output.clone(), &params.namespace)? {
+            CsvOutput::Namespace(ns) => {
+                for (name, csv) in ns {
+                    println!("\n{}\n{}\n\n{}\n", name, "-".repeat(name.len()), csv)
+                }
+            }
+            CsvOutput::SingleCollection(csv) => println!("{}", csv),
+        }
+
+        Ok(output)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CsvFileImportStrategy {
+    pub from_dir: PathBuf,
+    pub expect_header_row: bool,
+}
+
+impl ImportStrategy for CsvFileImportStrategy {
+    fn import(&self) -> Result<Namespace> {
+        let mut namespace = Namespace::new();
+
+        for entry in std::fs::read_dir(&self.from_dir)? {
+            let entry = entry?;
+
+            // Should a non-file in the directory be an error? Or should we just silently ignore?
+            if entry.file_type()?.is_file() {
+                let reader = csv::ReaderBuilder::new()
+                    .has_headers(self.expect_header_row)
+                    .from_path(entry.path())?;
+
+                let collection = import_csv_collection(reader, self.expect_header_row)?;
+
+                let mut name_string = entry.file_name().into_string().map_err(|_| {
+                    anyhow!("Failed to interpret collection name when importing a CSV namespace")
+                })?;
+                if name_string.ends_with(".csv") {
+                    name_string.truncate(name_string.len() - 4);
+                }
+
+                namespace.put_collection(name_string, collection)?;
+            }
+        }
+
+        Ok(namespace)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CsvStdinImportStrategy {
+    pub expect_header_row: bool,
+}
+
+impl ImportStrategy for CsvStdinImportStrategy {
+    fn import(&self) -> Result<Namespace> {
+        let stdin = std::io::stdin();
+        let reader = csv::ReaderBuilder::new()
+            .has_headers(self.expect_header_row)
+            .from_reader(stdin.lock());
+
+        let name = "collection".to_string();
+        import_csv_collection(reader, self.expect_header_row).map(|collection| {
+            let mut namespace = Namespace::new();
+            namespace.put_collection(name, collection).unwrap();
+            namespace
+        })
+    }
+}
+
+pub fn import_csv_collection(
+    mut reader: csv::Reader<impl std::io::Read>,
+    expect_header_row: bool,
+) -> Result<Content> {
+    let headers = if expect_header_row {
+        Some(headers::CsvHeaders::from_csv_header_record(
+            &reader.headers()?.clone(),
+        )?)
+    } else {
+        None
+    };
+
+    let mut records = reader.records();
+
+    let head = csv_record_to_value(
+        &records
+            .next()
+            .unwrap_or_else(|| Ok(csv::StringRecord::new()))?,
+        &headers,
+    )?;
+    let tail = records
+        .map(|res| res.map(|record| csv_record_to_value(&record, &headers)))
+        .collect::<csv::Result<Result<Vec<serde_json::Value>>>>()??;
+
+    let mut content = Content::from_value_wrapped_in_array(&head);
+
+    let mut values = vec![head];
+    values.extend(tail.into_iter());
+
+    OptionalMergeStrategy.try_merge(&mut content, &serde_json::Value::Array(values))?;
+
+    Ok(content)
+}
+
+fn csv_record_to_value(
+    row: &csv::StringRecord,
+    headers_opt: &Option<headers::CsvHeaders>,
+) -> Result<serde_json::Value> {
+    if let Some(headers) = headers_opt {
+        let first_header = match headers.iter().next() {
+            Some(h) => h,
+            None => return Ok(serde_json::Value::Null),
+        };
+
+        let mut final_value = match first_header.components_from_parent_to_child().first() {
+            Some(headers::CsvHeader::ArrayElement { .. }) => serde_json::Value::Array(Vec::new()),
+            Some(headers::CsvHeader::ObjectProperty { .. }) => {
+                serde_json::Value::Object(serde_json::Map::new())
+            }
+            None => return Ok(serde_json::Value::Null),
+        };
+
+        for (header, s) in headers.iter().zip(row.iter()) {
+            let mut current_value = &mut final_value;
+
+            let mut components = header
+                .components_from_parent_to_child()
+                .into_iter()
+                .peekable();
+
+            while let Some(component) = components.next() {
+                let to_insert = match components.peek() {
+                    Some(headers::CsvHeader::ArrayElement { .. }) => {
+                        serde_json::Value::Array(Vec::new())
+                    }
+                    Some(headers::CsvHeader::ObjectProperty { .. }) => {
+                        serde_json::Value::Object(serde_json::Map::new())
+                    }
+                    None => csv_str_to_value(s),
+                };
+
+                current_value = match component {
+                    headers::CsvHeader::ArrayElement { index, .. } => {
+                        let current_as_array = current_value.as_array_mut().unwrap();
+
+                        if current_as_array.len() == *index {
+                            current_as_array.push(to_insert);
+                        } else if current_as_array.is_empty()
+                            || current_as_array.len() - 1 != *index
+                        {
+                            return Err(anyhow!(
+                                "Invalid CSV headers - array indices should increase incrementally from 0."
+                            ));
+                        }
+
+                        current_as_array.get_mut(*index).unwrap()
+                    }
+                    headers::CsvHeader::ObjectProperty { key, .. } => {
+                        let current_as_object = current_value.as_object_mut().unwrap();
+
+                        current_as_object.entry(key).or_insert(to_insert);
+
+                        current_as_object.get_mut(key).unwrap()
+                    }
+                }
+            }
+        }
+
+        Ok(final_value)
+    } else {
+        let elements = row
+            .iter()
+            .map(csv_str_to_value)
+            .enumerate()
+            .map(|(i, val)| (format!("field{}", i), val))
+            .collect();
+
+        // Without headers, we can only assume the data was just a flat object.
+        Ok(serde_json::Value::Object(elements))
+    }
+}
+
+fn csv_str_to_value(s: &str) -> serde_json::Value {
+    if s.is_empty() {
+        serde_json::Value::Null
+    } else if s == "true" {
+        serde_json::Value::Bool(true)
+    } else if s == "false" {
+        serde_json::Value::Bool(false)
+    } else if let Ok(unsigned) = s.trim().parse::<u64>() {
+        serde_json::Value::Number(serde_json::Number::from(unsigned))
+    } else if let Ok(signed) = s.trim().parse::<i64>() {
+        serde_json::Value::Number(serde_json::Number::from(signed))
+    } else if let Ok(float) = s.trim().parse::<f64>() {
+        serde_json::Value::Number(serde_json::Number::from_f64(float).unwrap())
+    } else {
+        serde_json::Value::String(s.to_string())
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum CsvOutput {
+    Namespace(Vec<(String, String)>),
+    SingleCollection(String),
+}
+
+fn csv_output_from_sampler_ouput(
+    output: SamplerOutput,
+    namespace: &Namespace,
+) -> Result<CsvOutput> {
+    Ok(match output {
+        SamplerOutput::Namespace(key_values) => CsvOutput::Namespace(
+            key_values
+                .into_iter()
+                .map(|(collection_name, values)| {
+                    Ok((
+                        collection_name.clone(),
+                        to_csv_string(collection_name, values, namespace)?,
+                    ))
+                })
+                .collect::<Result<Vec<(String, String)>>>()?,
+        ),
+        SamplerOutput::Collection(collection_name, values) => {
+            CsvOutput::SingleCollection(to_csv_string(collection_name, values, namespace)?)
+        }
+    })
+}
+
+fn to_csv_string(
+    collection_name: String,
+    values: Vec<Value>,
+    namespace: &Namespace,
+) -> Result<String> {
+    match namespace.get_collection(&collection_name)? {
+        Content::Array(array_content) => {
+            let content = &*array_content.content;
+
+            let mut writer = csv::Writer::from_writer(vec![]);
+
+            writer.write_record(
+                &headers::CsvHeaders::from_content(content, namespace)?.to_csv_record(),
+            )?;
+
+            for val in values {
+                let record = synth_val_to_csv_record(val, content, namespace);
+                writer.write_record(record)?;
+            }
+
+            Ok(String::from_utf8(writer.into_inner()?)?)
+        }
+        _ => panic!("Outer-most `Content` of collection should be an array"),
+    }
+}
+
+fn synth_val_to_csv_record(val: Value, content: &Content, namespace: &Namespace) -> Vec<String> {
+    match val {
+        Value::Null(_) => vec![String::new()],
+        Value::Bool(b) => vec![b.to_string()],
+        Value::Number(n) => {
+            vec![match n {
+                Number::F32(f) => f.to_string(),
+                Number::F64(f) => f.to_string(),
+                _ => n.to_string(),
+            }]
+        }
+        Value::String(s) => vec![s],
+        Value::DateTime(dt) => vec![dt.format_to_string()],
+        Value::Object(obj_map) => {
+            let mut flatterned = Vec::new();
+
+            match content {
+                Content::Object(obj_content) => {
+                    for (field, obj_val) in obj_map.into_iter() {
+                        let inner_content = obj_content.fields.get(&field).unwrap();
+
+                        flatterned.extend(
+                            synth_val_to_csv_record(obj_val, inner_content, namespace).into_iter(),
+                        );
+                    }
+
+                    flatterned
+                }
+                _ => panic!("Schema and generated data don't align"),
+            }
+        }
+        Value::Array(elements) => {
+            let mut flatterned = Vec::new();
+
+            match content {
+                Content::Array(array_content) => {
+                    let expected_scalar_count = count_scalars_in_content(content, namespace);
+                    let scalar_count = elements.len()
+                        * count_scalars_in_content(&*array_content.content, namespace);
+
+                    let null_padding_iter = std::iter::repeat(Value::Null(()))
+                        .take(expected_scalar_count - scalar_count);
+
+                    let iter = elements.into_iter().chain(null_padding_iter).map(|elem| {
+                        synth_val_to_csv_record(elem, &*array_content.content, namespace)
+                    });
+
+                    for itm in iter {
+                        flatterned.extend(itm.into_iter());
+                    }
+
+                    flatterned
+                }
+                _ => panic!("Schema and generated data don't align"),
+            }
+        }
+    }
+}
+
+fn determine_content_array_max_length(array_content: &ArrayContent) -> usize {
+    if let Content::Number(NumberContent::U64(num)) = &*array_content.length {
+        (match num {
+            number_content::U64::Constant(constant) => *constant,
+            number_content::U64::Range(step) => {
+                let high = step.high.unwrap_or(u64::MAX);
+                if step.include_high {
+                    high
+                } else {
+                    high - 1
+                }
+            }
+            _ => panic!("Array's length should either be a constant or a range"),
+        }) as usize
+    } else {
+        panic!("Array's length should be a number generator")
+    }
+}
+
+fn count_scalars_in_content(content: &Content, ns: &Namespace) -> usize {
+    match content {
+        Content::Array(array_content) => {
+            determine_content_array_max_length(array_content)
+                * count_scalars_in_content(&*array_content.content, ns)
+        }
+        Content::Object(obj_content) => obj_content
+            .iter()
+            .map(|(_, x)| count_scalars_in_content(x, ns))
+            .sum(),
+        Content::SameAs(same_as) => {
+            count_scalars_in_content(ns.get_s_node(&same_as.ref_).unwrap(), ns)
+        }
+        Content::OneOf(one_of) => one_of
+            .variants
+            .iter()
+            .map(|x| count_scalars_in_content(&x.content, ns))
+            .sum(),
+        Content::Unique(unique) => count_scalars_in_content(&unique.content, ns),
+        _ => 1,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_csv_record_to_value() {
+        assert_eq!(
+            csv_record_to_value(
+                &csv::StringRecord::from(vec!["true", "false", "true", "false"]),
+                &Some(
+                    headers::CsvHeaders::from_csv_header_record(&csv::StringRecord::from(vec![
+                        "a[0][0]", "a[0][1]", "a[1][0]", "a[1][1]"
+                    ]))
+                    .unwrap()
+                )
+            )
+            .unwrap(),
+            serde_json::json!({
+                "a": [
+                    [true, false],
+                    [true, false]
+                ]
+            })
+        );
+
+        assert!(csv_record_to_value(
+            &csv::StringRecord::from(vec!["1", "2", "3"]),
+            &Some(
+                headers::CsvHeaders::from_csv_header_record(&csv::StringRecord::from(vec![
+                    "a[0][0]", "a[0][1]", "a[2][0]", "a[1][1]"
+                ]))
+                .unwrap()
+            )
+        )
+        .is_err());
+
+        assert!(csv_record_to_value(
+            &csv::StringRecord::from(vec!["1", "2"]),
+            &Some(
+                headers::CsvHeaders::from_csv_header_record(&csv::StringRecord::from(vec![
+                    "a[1]", "a[0]"
+                ]))
+                .unwrap()
+            )
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_csv_output_from_sampler_output() {
+        let content = serde_json::from_str(
+            "{
+                \"type\": \"array\",
+                \"length\": {
+                    \"type\": \"number\",
+                    \"subtype\": \"u64\",
+                    \"range\": {
+                        \"low\": 1,
+                        \"high\": 2,
+                        \"step\": 1
+                    }
+                },
+                \"content\": {
+                    \"type\": \"object\",
+                    \"a\": {
+                        \"type\": \"object\",
+                        \"b\": {
+                            \"type\": \"string\",
+                            \"pattern\": \"hello world\"
+                        },
+                        \"c\": {
+                            \"type\": \"same_as\",
+                            \"ref\": \"collection.content.a.b\"
+                        },
+                        \"d\": {
+                            \"type\": \"array\",
+                            \"length\": {
+                                \"type\": \"number\",
+                                \"subtype\": \"u64\",
+                                \"range\": {
+                                    \"low\": 2,
+                                    \"high\": 3,
+                                    \"step\": 1
+                                }
+                            },
+                            \"content\": {
+                                \"type\": \"object\",
+                                \"e\": {
+                                    \"type\": \"bool\",
+                                    \"constant\": true
+                                },
+                                \"f\": {
+                                    \"type\": \"bool\",
+                                    \"constant\": false
+                                }
+                            }
+                        }
+                    }
+                }
+            }",
+        )
+        .unwrap();
+
+        let collection_name = "collection".to_string();
+
+        let mut ns = Namespace::new();
+        ns.put_collection(collection_name.clone(), content).unwrap();
+
+        let generator = Sampler::try_from(&ns).unwrap();
+        let output = generator
+            .sample_seeded(Some(collection_name), 1, 0)
+            .unwrap();
+
+        assert_eq!(
+            csv_output_from_sampler_ouput(output, &ns).unwrap(),
+            CsvOutput::SingleCollection(
+                concat!(
+                    "a.b,a.c,a.d[0].e,a.d[0].f,a.d[1].e,a.d[1].f\n",
+                    "hello world,hello world,true,false,true,false\n"
+                )
+                .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_csv_str_to_value() {
+        assert_eq!(
+            csv_str_to_value("the quick brown fox"),
+            serde_json::Value::String("the quick brown fox".to_string())
+        );
+
+        assert_eq!(csv_str_to_value("true"), serde_json::Value::Bool(true));
+        assert_eq!(csv_str_to_value("false"), serde_json::Value::Bool(false));
+        assert!(matches!(
+            csv_str_to_value("TrUe"),
+            serde_json::Value::String(_)
+        ));
+
+        assert_eq!(csv_str_to_value("64"), serde_json::json!(64));
+        assert_eq!(csv_str_to_value("-64"), serde_json::json!(-64));
+        assert_eq!(csv_str_to_value("64.1"), serde_json::json!(64.1));
+    }
+}

--- a/synth/src/cli/export.rs
+++ b/synth/src/cli/export.rs
@@ -1,3 +1,4 @@
+use crate::cli::csv::{CsvFileExportStrategy, CsvStdoutExportStrategy};
 use crate::cli::json::{JsonFileExportStrategy, JsonStdoutExportStrategy};
 use crate::cli::jsonl::{JsonLinesFileExportStrategy, JsonLinesStdoutExportStrategy};
 use crate::cli::mongo::MongoExportStrategy;
@@ -14,7 +15,7 @@ use crate::sampler::{Sampler, SamplerOutput};
 use async_std::task;
 use synth_core::{DataSourceParams, Namespace, Value};
 
-use super::collection_field_name_from_uri_query;
+use super::map_from_uri_query;
 
 pub(crate) trait ExportStrategy {
     fn export(&self, params: ExportParams) -> Result<SamplerOutput>;
@@ -36,6 +37,8 @@ impl TryFrom<DataSourceParams<'_>> for Box<dyn ExportStrategy> {
         // Due to all the schemes used, with the exception of 'mongodb', being non-standard (including 'postgres' and
         // 'mysql' suprisingly) it seems simpler to just match based on the scheme string instead of on enum variants.
         let scheme = params.uri.scheme().as_str().to_lowercase();
+        let query = map_from_uri_query(params.uri.query());
+
         let export_strategy: Box<dyn ExportStrategy> = match scheme.as_str() {
             "postgres" | "postgresql" => Box::new(PostgresExportStrategy {
                 uri_string: params.uri.to_string(),
@@ -57,8 +60,10 @@ impl TryFrom<DataSourceParams<'_>> for Box<dyn ExportStrategy> {
                 }
             }
             "jsonl" => {
-                let collection_field_name =
-                    collection_field_name_from_uri_query(params.uri.query());
+                let collection_field_name = query
+                    .get("collection_field_name")
+                    .unwrap_or(&"type")
+                    .to_string();
 
                 if params.uri.path() == "" {
                     Box::new(JsonLinesStdoutExportStrategy {
@@ -71,9 +76,18 @@ impl TryFrom<DataSourceParams<'_>> for Box<dyn ExportStrategy> {
                     })
                 }
             }
+            "csv" => {
+                if params.uri.path() == "" {
+                    Box::new(CsvStdoutExportStrategy)
+                } else {
+                    Box::new(CsvFileExportStrategy {
+                        to_dir: PathBuf::from(params.uri.path().to_string()),
+                    })
+                }
+            }
             _ => {
                 return Err(anyhow!(
-                    "Export URI scheme not recognised. Was expecting one of 'mongodb', 'postgres', 'mysql', 'mariadb', 'json' or 'jsonl'."
+                    "Export URI scheme not recognised. Was expecting one of 'mongodb', 'postgres', 'mysql', 'mariadb', 'json', 'jsonl' or 'csv'."
                 ));
             }
         };

--- a/synth/src/cli/mod.rs
+++ b/synth/src/cli/mod.rs
@@ -1,3 +1,4 @@
+mod csv;
 mod export;
 mod import;
 mod import_utils;
@@ -17,7 +18,9 @@ use anyhow::{Context, Result};
 use rand::RngCore;
 use serde::Serialize;
 use std::cell::Cell;
+use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
+use std::iter::FromIterator;
 use std::path::PathBuf;
 use structopt::clap::AppSettings;
 use structopt::StructOpt;
@@ -268,7 +271,7 @@ pub enum Args {
         size: usize,
         #[structopt(
             long,
-            help = "The URI into which data will be generated. Can be a file-based URI scheme to output data to the filesystem or stdout ('json:' and 'jsonl:' allow outputting JSON and JSON Lines data respectively) or can be a database URI to write data directly to some database (supports Postgres, MongoDB, and MySQL). Defaults to writing JSON data to stdout.",
+            help = "The URI into which data will be generated. Can be a file-based URI scheme to output data to the filesystem or stdout ('json:', 'jsonl:' and 'csv:' allow outputting JSON, JSON Lines and CSV data respectively) or can be a database URI to write data directly to some database (supports Postgres, MongoDB, and MySQL). Defaults to writing JSON data to stdout. [example: jsonl:/tmp/generation_output]",
             default_value = "json:"
         )]
         #[serde(skip)]
@@ -306,7 +309,7 @@ pub enum Args {
         collection: Option<String>,
         #[structopt(
             long,
-            help = "The source URI from which to import data. Can be a file-based URI scheme to read data from a file or stdin ('json:' and 'jsonl:' allow reading JSON and JSON Lines data respectively) or can be a database URI to read data directly from some database (supports Postgres, MongoDB, and MySQL). Defaults to reading JSON data from stdin.",
+            help = "The source URI from which to import data. Can be a file-based URI scheme to read data from a file or stdin ('json:', 'jsonl:' and 'csv:' allow reading JSON, JSON Lines and CSV data respectively) or can be a database URI to read data directly from some database (supports Postgres, MongoDB, and MySQL). Defaults to reading JSON data from stdin. [example: jsonl:/tmp/test_data_input]",
             default_value = "json:"
         )]
         #[serde(skip)]
@@ -325,14 +328,10 @@ pub enum Args {
     Version,
 }
 
-fn collection_field_name_from_uri_query(query_opt: Option<&uriparse::Query>) -> String {
+fn map_from_uri_query<'a>(query_opt: Option<&'a uriparse::Query<'a>>) -> HashMap<&'a str, &'a str> {
     let query_str = query_opt.map(uriparse::Query::as_str).unwrap_or_default();
 
-    querystring::querify(query_str)
-        .into_iter()
-        .find_map(|(key, value)| (key == "collection_field_name").then(|| value))
-        .unwrap_or("type")
-        .to_string()
+    HashMap::<_, _>::from_iter(querystring::querify(query_str).into_iter())
 }
 
 #[cfg(feature = "telemetry")]


### PR DESCRIPTION
Addresses issue: https://github.com/getsynth/synth/issues/33

This PR implements importing and exporting of CSV data to/from Synth schemas. CSV is a very flexible, loosely-defined format so I've had to make some assumptions about how data is formatted - these are as follows:

* Headers are defined using the following syntax: `(name | "[" number "]" ) ( "." name | "[" number "]" )*`
  * `[x]` where `x` is some integer defines an value in an array.
  * `a.b` is some member `b` of object `a`.
  * `a[x][y]` is an element of a 2D array on object member `a`.
* Headers in import data are not mandatory (add `?header_row=false` to `--from` URI) - when headers are not present, a schema is created that generates a flat object with field names in the format `fieldX` where `X` is incremental.
* All rows have the same number of elements - when generating schemas with arrays of variable length, the full length of the array is outputted padded with null values. For example, an array that could up to 4 elements long but in a particular instance is just 2 long would be encoded in CSV as `1,2,,`.
* `one_of` generators can only have variants that are scalar values (i.e. no objects or arrays).

Some things to consider:

* When importing CSV you can specify whether or not there exists a header row in your import data (default: true) with a URI argument, e.g. `import --from csv:directory?header_row=false` - I don't really like this way of doing it and would rather something like `import --from csv:directory?no_header_row` (like a CLI flag argument) but this currently isn't doable with the URI query parsing library used. Perhaps it's worth switching it out for a different library or even coding it ourselves?
* I have written some tests but due to the complexity of this feature I feel like more/more thorough tests would be worthwhile. I'm planning to write some later today/tomorrow but wanted to submit the PR first so that it can be scrutinised beforehand!
* Regarding variable-length arrays - when exporting, arrays are padded with null values up to the maximum possible length of the array, but when importing such data gets interpreted as an array of the maximum size containing `one_of` generator between the type actually contained in the original array and null. Perhaps this is problematic, but I'm not sure how it would be possible to determine from just CSV data whether the intention was a variable-length array or a fixed-length array of `one_of` generators.