### PR TITLE
ci: MacOs release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         toolchain: nightly
     - id: tag
       uses: dawidd6/action-get-tag@v1
-    - run: cargo +nightly build --release --features telemetry
+    - run: cargo +nightly build --release --features telemetry --bin synth
     - working-directory: target/release
       run: tar -czf synth.tar.gz synth
     - uses: actions/upload-artifact@v2
@@ -45,7 +45,7 @@ jobs:
         toolchain: nightly
     - id: tag
       uses: dawidd6/action-get-tag@v1
-    - run: cargo +nightly build --release --features telemetry
+    - run: cargo +nightly build --release --features telemetry --bin synth
     - run: sudo /usr/sbin/purge
     - working-directory: target/release
       run: tar -czf synth.tar.gz synth
@@ -69,7 +69,7 @@ jobs:
         run: |
           VERSION=$(cargo metadata --format-version 1 | jq '.packages[] | select (.name == "synth") | .version' -r)
           echo "::set-output name=version::${VERSION}"
-      - run: cargo +nightly build --release --features telemetry
+      - run: cargo +nightly build --release --features telemetry --bin synth
       - id: install-wix
         run: nuget install WiX -Version 3.11.2
       - id: install-cargo-wix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,6 @@ jobs:
       matrix:
         os:
         - ubuntu-latest
-        - macos-10.15
         # Build for these versions to force backward compat with certain
         # toolchains (GLIBC < 2.29 in case of ubuntu-18.04)
         - ubuntu-18.04
@@ -34,6 +33,25 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: synth-${{ steps.tag.outputs.tag }}-${{ matrix.os }}-x86_64
+        path: target/release/synth.tar.gz
+
+  build-osx:
+    name: build
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+    - id: tag
+      uses: dawidd6/action-get-tag@v1
+    - run: cargo +nightly build --release --features telemetry
+    - run: sudo /usr/sbin/purge
+    - working-directory: target/release
+      run: tar -czf synth.tar.gz synth
+    - uses: actions/upload-artifact@v2
+      with:
+        name: synth-${{ steps.tag.outputs.tag }}-osx-latest-x86_64
         path: target/release/synth.tar.gz
 
   build-windows:
@@ -83,7 +101,7 @@ jobs:
 
   release:
     name: release
-    needs: [ build, build-windows ]
+    needs: [ build, build-osx, build-windows ]
     runs-on: ubuntu-latest
     steps:
     - id: tag


### PR DESCRIPTION
Fixes the macos release build by adding a `sudo /usr/sbin/purge` step. This step does not exist on Linux so a new run was added just for macos. An example of this working can be seen [here](https://github.com/chesedo/synth/runs/4124732473?check_suite_focus=true).

This also adds a small `--bin synth` optimization since the release build does not need the playground binary - reduces the build crates from ~260 to ~240.

Closes #216 