### PR TITLE
fix(build): remove the "unused manifest key" warning.

### DIFF
--- a/synth/.cargo/config.toml
+++ b/synth/.cargo/config.toml
@@ -10,3 +10,9 @@ rustflags = [
     "-C", "link-arg=-undefined",
     "-C", "link-arg=dynamic_lookup",
 ]
+
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.i686-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/synth/Cargo.toml
+++ b/synth/Cargo.toml
@@ -18,12 +18,6 @@ harness = false
 default = []
 telemetry = ["posthog-rs", "uuid", "backtrace", "console"]
 
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]
-
-[target.i686-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]
-
 [build-dependencies]
 git2 = "0.13.20"
 


### PR DESCRIPTION
At least on Linux, building the project was causing the following
warnings to be issued:

warning: synth/Cargo.toml: unused manifest key: target.i686-pc-windows-msvc.rustflags
warning: synth/Cargo.toml: unused manifest key: target.x86_64-pc-windows-msvc.rustflags

These configuration settings were moved from synth/Cargo.toml to
synth/.cargo/config.toml as recommended in the Cargo book
(https://doc.rust-lang.org/cargo/reference/config.html).

Additionally, the configuration file was renamed to config.toml, which
is also recommended by the aforementioned book.