### PR TITLE
fix: remove trailing GitHub GET request

### DIFF
--- a/synth/src/cli/mod.rs
+++ b/synth/src/cli/mod.rs
@@ -20,7 +20,6 @@ use serde::Serialize;
 use std::cell::Cell;
 use std::convert::{TryFrom, TryInto};
 use std::path::PathBuf;
-use std::process::exit;
 use structopt::clap::AppSettings;
 use structopt::StructOpt;
 use synth_core::Name;
@@ -110,8 +109,7 @@ impl Cli {
             Args::Telemetry(cmd) => self.telemetry(cmd),
             Args::Version => {
                 print_version_message();
-                // Exiting so we don't get the message twice
-                exit(0);
+                Ok(())
             }
         }
     }


### PR DESCRIPTION
Currently, running synth version causes two GET requests to be
dispatched to GitHub in order to check for new Synth versions, wich can
be verified by running RUST_LOG=debug synth version.

This removes the additional request, and now only the child thread
spawned at the main function will be resposible for checking for
updates.