### PR TITLE
feat: cache GitHub GET requests

### DIFF
--- a/synth/Cargo.toml
+++ b/synth/Cargo.toml
@@ -61,7 +61,7 @@ futures = "0.3.15"
 
 fs2 = "0.4.3"
 
-chrono = "0.4.18"
+chrono = { version = "0.4.18", features = ["serde"] }
 regex = "1.3.9"
 rand = "0.8.3"
 ctrlc = { version = "3.0", features = ["termination"] }

--- a/synth/src/cli/config.rs
+++ b/synth/src/cli/config.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use chrono::{DateTime, Utc};
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -43,6 +44,7 @@ config! {
     uuid: String => get_uuid, set_uuid
     telemetry_enabled: bool => get_telemetry_enabled, set_telemetry_enabled
     seen_versions: HashSet<String> => get_seen_versions, set_seen_versions
+    version_check_delay: DateTime<Utc> => get_version_check_delay, set_version_check_delay
 }
 
 impl Config {


### PR DESCRIPTION
Implement caching for the GitHub GET requests. I defined the cached field to be valid for seven days. Let me know if it should be valid for longer or shorter periods.