### PR TITLE
docs: update example to use `date_time` type instead of `string`

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,14 +102,11 @@ Next let's create a `users` collection using Synth's configuration language, and
             }
         },
         "joined_on": {
-            "type": "object",
-            "date": {
-                "type": "date_time",
-                "format": "%Y-%m-%d",
-                "subtype": "naive_date",
-                "begin": "2010-01-01",
-                "end": "2020-01-01"
-            }
+            "type": "date_time",
+            "format": "%Y-%m-%d",
+            "subtype": "naive_date",
+            "begin": "2010-01-01",
+            "end": "2020-01-01"
         }
     }
 }
@@ -124,16 +121,12 @@ $ synth generate my_app/ --size 2 | jq
     {
       "email": "patricia40@jordan.com",
       "id": 1,
-      "joined_on": {
-        "date": "2014-12-14
-      }
+      "joined_on": "2014-12-14"
     },
     {
       "email": "benjamin00@yahoo.com",
       "id": 2,
-      "joined_on": {
-        "date": "2013-04-06"
-      }
+      "joined_on": "2013-04-06"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -102,8 +102,9 @@ Next let's create a `users` collection using Synth's configuration language, and
             }
         },
         "joined_on": {
-            "type": "string",
-            "date_time": {
+            "type": "object",
+            "date": {
+                "type": "date_time",
                 "format": "%Y-%m-%d",
                 "subtype": "naive_date",
                 "begin": "2010-01-01",
@@ -123,12 +124,16 @@ $ synth generate my_app/ --size 2 | jq
     {
       "email": "patricia40@jordan.com",
       "id": 1,
-      "joined_on": "2014-12-14"
+      "joined_on": {
+        "date": "2014-12-14
+      }
     },
     {
       "email": "benjamin00@yahoo.com",
       "id": 2,
-      "joined_on": "2013-04-06"
+      "joined_on": {
+        "date": "2013-04-06"
+      }
     }
   ]
 }


### PR DESCRIPTION
Addresses https://github.com/getsynth/synth/issues/257

Before:
```bash
➜  synth generate try-synth/ --size 2 | jq
Error: Unable to open the namespace "try-synth/"

Caused by:
    0: at file try-synth/users.json
    1: Failed to parse collection
    2: unknown variant `date_time`, expected one of `pattern`, `faker`, `categorical`, `serialized`, `uuid`, `truncated`, `format` at line 29 column 1
```

After:
```bash
➜  synth generate try-synth/ --size 2 | jq
{
  "users": [
    {
      "email": "margarete@example.org",
      "id": 1,
      "joined_on": "2016-03-04"
    },
    {
      "email": "brody@example.com",
      "id": 2,
      "joined_on": "2016-07-08"
    }
  ]
}
```