### PR TITLE
Fix misc build issues

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -14,9 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install nix
-        uses: cachix/install-nix-action@v12
+        uses: cachix/install-nix-action@v16
       - name: Setup cachix
-        uses: cachix/cachix-action@v8
+        uses: cachix/cachix-action@v10
         with:
           name: getsynth
           authToken: ${{ secrets.CACHIX_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3175,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "synth"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "async-std",

--- a/default.nix
+++ b/default.nix
@@ -13,7 +13,7 @@
 , release ? true
 }:
 let
-  version = "0.6.1";
+  version = "0.6.2";
   darwinBuildInputs =
     stdenv.lib.optionals stdenv.hostPlatform.isDarwin (with darwin.apple_sdk.frameworks; [
       libiconv

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -4,7 +4,7 @@
 self: super: {
   synthPackages = {
     rustToolchain = super.rustChannelOf {
-      date = "2021-09-15";
+      date = "2021-12-10";
       channel = "nightly";
     };
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nmattia",
         "repo": "naersk",
-        "rev": "4f7426c362809e472d03c369d3674317c32b6863",
-        "sha256": "1c0f2c4gkfmrpykmk25ck8x17nq7l14di8vvxlibbigzy5jacdaf",
+        "rev": "ebde51ec0eec82dc71eaca03bc24cf8eb44a3d74",
+        "sha256": "0bh0hpzhyawa8w3mll96i1fg4zrzr40vjafpp6k42hxrzx280spb",
         "type": "tarball",
-        "url": "https://github.com/nmattia/naersk/archive/4f7426c362809e472d03c369d3674317c32b6863.tar.gz",
+        "url": "https://github.com/nmattia/naersk/archive/ebde51ec0eec82dc71eaca03bc24cf8eb44a3d74.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
@@ -17,10 +17,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "e9e31a7248e0728ab67a5a911b7ef704b1e399c4",
-        "sha256": "0xc781ivc0qrbnvk3njfz6xxpfqr46f5gw5ykjc0588jy86bmk91",
+        "rev": "5830a4dd348d77e39a0f3c4c762ff2663b602d4c",
+        "sha256": "1d3lsrqvci4qz2hwjrcnd8h5vfkg8aypq3sjd4g3izbc8frwz5sm",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/e9e31a7248e0728ab67a5a911b7ef704b1e399c4.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/5830a4dd348d77e39a0f3c4c762ff2663b602d4c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nix-bundle": {
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "matthewbauer",
         "repo": "nix-bundle",
-        "rev": "8e396533ef8f3e8a769037476824d668409b4a74",
-        "sha256": "1lrq0990p07av42xz203w64abv2rz9xd8jrzxyvzzwj7vjj7qwyw",
+        "rev": "223f4ffc4179aa318c34dc873a08cb00090db829",
+        "sha256": "0pqpx9vnjk9h24h9qlv4la76lh5ykljch6g487b26r1r2s9zg7kh",
         "type": "tarball",
-        "url": "https://github.com/matthewbauer/nix-bundle/archive/8e396533ef8f3e8a769037476824d668409b4a74.tar.gz",
+        "url": "https://github.com/matthewbauer/nix-bundle/archive/223f4ffc4179aa318c34dc873a08cb00090db829.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -41,10 +41,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "51bb9f3e9ab6161a3bf7746e20b955712cef618b",
-        "sha256": "1bqla14c80ani27c7901rnl37kiiqrvyixs6ifvm48p5y6xbv1p7",
+        "rev": "c473cc8714710179df205b153f4e9fa007107ff9",
+        "sha256": "0q7rnlp1djxc9ikj89c0ifzihl4wfvri3q1bvi75d2wrz844b4lq",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/51bb9f3e9ab6161a3bf7746e20b955712cef618b.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/c473cc8714710179df205b153f4e9fa007107ff9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-mozilla": {
@@ -53,10 +53,10 @@
         "homepage": null,
         "owner": "mozilla",
         "repo": "nixpkgs-mozilla",
-        "rev": "3f3fba4e2066f28a1ad7ac60e86a688a92eb5b5f",
-        "sha256": "1mrj89gzrzhci4lssvzmmk31l715cddp7l39favnfs1qaijly814",
+        "rev": "7c1e8b1dd6ed0043fb4ee0b12b815256b0b9de6f",
+        "sha256": "1a71nfw7d36vplf89fp65vgj3s66np1dc0hqnqgj5gbdnpm1bihl",
         "type": "tarball",
-        "url": "https://github.com/mozilla/nixpkgs-mozilla/archive/3f3fba4e2066f28a1ad7ac60e86a688a92eb5b5f.tar.gz",
+        "url": "https://github.com/mozilla/nixpkgs-mozilla/archive/7c1e8b1dd6ed0043fb4ee0b12b815256b0b9de6f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/synth/Cargo.toml
+++ b/synth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "synth"
-version = "0.6.1"
+version = "0.6.2"
 authors = [
   "Damien Broka <damien@getsynth.com>",
   "Christos Hadjiaslanis <christos@getsynth.com>",


### PR DESCRIPTION
This
- updates some `nix` dependencies to fix the CI and 
- bumps the `Cargo.toml` and `default.nix` version for `synth` to align with release (thus closes #259).