### PR TITLE
refactor: remove `Name` struct

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -94,7 +94,7 @@ pub use error::Error;
 
 #[macro_use]
 pub mod schema;
-pub use schema::{Content, Name, Namespace};
+pub use schema::{Content, Namespace};
 
 pub mod graph;
 pub use graph::{Graph, Value};

--- a/core/src/schema/content/mod.rs
+++ b/core/src/schema/content/mod.rs
@@ -259,6 +259,13 @@ content! {
 }
 
 impl Content {
+    pub fn from_value_wrapped_in_array(value: &Value) -> Self {
+        Content::Array(ArrayContent {
+            length: Box::new(Content::from(&Value::from(1))),
+            content: Box::new(value.into()),
+        })
+    }
+
     pub fn is_null(&self) -> bool {
         matches!(self, Self::Null(_))
     }

--- a/core/src/schema/content/mod.rs
+++ b/core/src/schema/content/mod.rs
@@ -323,7 +323,7 @@ impl Content {
             Content::Object(ObjectContent { fields, .. }) => {
                 let mut namespace = Namespace::new();
                 for (key, content) in fields.into_iter() {
-                    namespace.put_collection(&key.parse()?, content)?;
+                    namespace.put_collection(key, content)?;
                 }
                 Ok(namespace)
             }

--- a/core/src/schema/inference/mod.rs
+++ b/core/src/schema/inference/mod.rs
@@ -378,8 +378,7 @@ impl MergeStrategy<NumberContent, Number> for OptionalMergeStrategy {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::{Name, Namespace};
-    use std::str::FromStr;
+    use crate::Namespace;
 
     macro_rules! as_array {
         [$($ident:ident)*] => {
@@ -407,9 +406,9 @@ pub mod tests {
         let user_no_last_name_as_array = as_array![user_no_last_name];
         let user_no_address_as_array = as_array![user_no_address];
 
-        let collection_name = Name::from_str("users").unwrap();
+        let collection_name = "users".to_string();
         let mut ns = Namespace::default();
-        ns.create_collection(&collection_name, &user_no_last_name)
+        ns.create_collection(collection_name.clone(), &user_no_last_name)
             .unwrap();
         assert!(ns
             .accepts(&collection_name, &user_no_last_name_as_array)
@@ -451,9 +450,9 @@ pub mod tests {
         let user_no_address_as_array = as_array![user_no_address];
         let user_no_last_name_as_array = as_array![user_no_last_name];
 
-        let collection_name = Name::from_str("users").unwrap();
+        let collection_name = "users".to_string();
         let mut ns = Namespace::default();
-        ns.create_collection(&collection_name, &user_no_last_name)
+        ns.create_collection(collection_name.clone(), &user_no_last_name)
             .unwrap();
         ns.try_update(
             OptionalMergeStrategy,
@@ -504,9 +503,9 @@ pub mod tests {
         let user_no_address_as_array = as_array![user_no_address];
         let user_no_last_name_as_array = as_array![user_no_last_name];
 
-        let collection_name = Name::from_str("users").unwrap();
+        let collection_name = "users".to_string();
         let mut ns = Namespace::default();
-        ns.create_collection(&collection_name, &user_no_last_name)
+        ns.create_collection(collection_name.clone(), &user_no_last_name)
             .unwrap();
         ns.try_update(
             OptionalMergeStrategy,

--- a/core/src/schema/inference/mod.rs
+++ b/core/src/schema/inference/mod.rs
@@ -408,7 +408,7 @@ pub mod tests {
 
         let collection_name = "users".to_string();
         let mut ns = Namespace::default();
-        ns.create_collection(collection_name.clone(), &user_no_last_name)
+        ns.put_collection_from_json(collection_name.clone(), &user_no_last_name)
             .unwrap();
         assert!(ns
             .accepts(&collection_name, &user_no_last_name_as_array)
@@ -452,7 +452,7 @@ pub mod tests {
 
         let collection_name = "users".to_string();
         let mut ns = Namespace::default();
-        ns.create_collection(collection_name.clone(), &user_no_last_name)
+        ns.put_collection_from_json(collection_name.clone(), &user_no_last_name)
             .unwrap();
         ns.try_update(
             OptionalMergeStrategy,
@@ -505,7 +505,7 @@ pub mod tests {
 
         let collection_name = "users".to_string();
         let mut ns = Namespace::default();
-        ns.create_collection(collection_name.clone(), &user_no_last_name)
+        ns.put_collection_from_json(collection_name.clone(), &user_no_last_name)
             .unwrap();
         ns.try_update(
             OptionalMergeStrategy,

--- a/core/src/schema/mod.rs
+++ b/core/src/schema/mod.rs
@@ -10,8 +10,6 @@ use serde::{
 };
 use serde_json::Value as JsonValue;
 
-use crate::error::Error;
-
 pub mod inference;
 pub use inference::{MergeStrategy, OptionalMergeStrategy, ValueMergeStrategy};
 
@@ -44,7 +42,7 @@ impl ValueKindExt for JsonValue {
     }
 }
 
-const NAME_RE: &str = "[A-Za-z_0-9]+";
+//const NAME_RE: &str = "[A-Za-z_0-9]+";
 
 #[allow(dead_code)]
 pub fn bool_from_str<'de, D: Deserializer<'de>>(d: D) -> std::result::Result<bool, D::Error> {
@@ -53,79 +51,67 @@ pub fn bool_from_str<'de, D: Deserializer<'de>>(d: D) -> std::result::Result<boo
         .parse()
         .map_err(|e| D::Error::custom(format!("not a boolean: {}", e)))
 }
-
-#[derive(Hash, PartialEq, Eq, Debug, Clone, Ord, PartialOrd)]
-pub struct Name(String);
-
-impl Name {
-    #[allow(dead_code)]
-    pub fn distance(&self, other: &Name) -> usize {
-        strsim::levenshtein(&self.0, &other.0)
-    }
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct FieldRef {
+    collection: String,
+    fields: Vec<String>,
 }
 
-impl FromStr for Name {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        lazy_static! {
-            static ref RE: Regex = Regex::new(NAME_RE).unwrap();
-        }
-        let s = s.to_string();
-        if RE.is_match(&s) {
-            Ok(Self(s))
-        } else {
-            Err(Self::Err::bad_request(format!("illegal name: {}", s)))
-        }
-    }
-}
-
-impl std::convert::AsRef<str> for Name {
-    fn as_ref(&self) -> &str {
-        self.0.as_str()
-    }
-}
-
-impl std::fmt::Display for Name {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl Serialize for Name {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+impl Serialize for FieldRef {
+    fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
     where
-        S: serde::Serializer,
+        S: Serializer,
     {
-        self.0.serialize(serializer)
+        serializer.serialize_str(&format!("{}", &self))
     }
 }
 
-impl<'de> Deserialize<'de> for Name {
+impl<'de> Deserialize<'de> for FieldRef {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        let as_str = String::deserialize(deserializer)?;
-        Self::from_str(&as_str).map_err(|err| {
-            let msg = format!("invalid name: {}", err);
-            D::Error::custom(msg)
-        })
+        let s = String::deserialize(deserializer)?;
+        FromStr::from_str(&s).map_err(de::Error::custom)
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub struct FieldRef {
-    collection: Name,
-    fields: Vec<String>,
+impl FromStr for FieldRef {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let lexer = Lexer::lex(s.to_string());
+
+        let parser = Parser::new(lexer);
+
+        parser.parse()
+    }
 }
 
-impl From<Name> for FieldRef {
-    fn from(collection: Name) -> Self {
-        Self {
-            collection,
-            fields: Vec::new(),
+impl IntoIterator for FieldRef {
+    type IntoIter = Chain<Once<String>, <Vec<String> as IntoIterator>::IntoIter>;
+    type Item = String;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        std::iter::once(self.collection.to_string()).chain(self.fields.into_iter())
+    }
+}
+
+impl std::fmt::Display for FieldRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (i, chunk) in self.iter().enumerate() {
+            if i != 0 {
+                write!(f, ".")?
+            }
+
+            if chunk.contains('.') {
+                write!(f, "\"{}\"", chunk)?
+            } else {
+                write!(f, "{}", chunk)?
+            }
         }
+        Ok(())
     }
 }
 
@@ -135,7 +121,14 @@ impl FieldRef {
         Self::from_str(s.as_ref())
     }
 
-    pub fn collection(&self) -> &Name {
+    pub fn from_collection_name(collection: String) -> Self {
+        Self {
+            collection,
+            fields: Vec::new(),
+        }
+    }
+
+    pub fn collection(&self) -> &str {
         &self.collection
     }
 
@@ -161,7 +154,7 @@ impl FieldRef {
     pub(crate) fn last(&self) -> String {
         match self.fields.last() {
             Some(field) => field.clone(),
-            None => self.collection.clone().to_string(),
+            None => self.collection.clone(),
         }
     }
 
@@ -236,7 +229,7 @@ impl Parser {
         }
 
         Ok(FieldRef {
-            collection: Name::from_str(&self.collection)?,
+            collection: self.collection,
             fields: self.field_chunks,
         })
     }
@@ -348,64 +341,6 @@ enum Token {
     Quote,
 }
 
-impl Serialize for FieldRef {
-    fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(&format!("{}", &self))
-    }
-}
-
-impl<'de> Deserialize<'de> for FieldRef {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        FromStr::from_str(&s).map_err(de::Error::custom)
-    }
-}
-
-impl FromStr for FieldRef {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let lexer = Lexer::lex(s.to_string());
-
-        let parser = Parser::new(lexer);
-
-        parser.parse()
-    }
-}
-
-impl IntoIterator for FieldRef {
-    type IntoIter = Chain<Once<String>, <Vec<String> as IntoIterator>::IntoIter>;
-    type Item = String;
-
-    #[inline]
-    fn into_iter(self) -> Self::IntoIter {
-        std::iter::once(self.collection.to_string()).chain(self.fields.into_iter())
-    }
-}
-
-impl std::fmt::Display for FieldRef {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for (i, chunk) in self.iter().enumerate() {
-            if i != 0 {
-                write!(f, ".")?
-            }
-
-            if chunk.contains('.') {
-                write!(f, "\"{}\"", chunk)?
-            } else {
-                write!(f, "{}", chunk)?
-            }
-        }
-        Ok(())
-    }
-}
-
 #[cfg(test)]
 pub mod tests {
     use std::collections::BTreeMap;
@@ -418,13 +353,13 @@ pub mod tests {
     fn test_new() {
         let reference: FieldRef = "users.address.postcode".parse().unwrap();
         println!("{:?}", reference);
-        assert_eq!("users".parse::<Name>().unwrap(), *reference.collection());
+        assert_eq!("users".to_string(), *reference.collection());
         let mut fields = reference.iter_fields();
         assert_eq!("address", fields.next().unwrap());
         assert_eq!("postcode", fields.next().unwrap());
 
         let reference: FieldRef = "users.\"address.postcode\"".parse().unwrap();
-        assert_eq!("users".parse::<Name>().unwrap(), *reference.collection());
+        assert_eq!("users".to_string(), *reference.collection());
         let mut fields = reference.iter_fields();
         assert_eq!("address.postcode", fields.next().unwrap());
     }
@@ -504,7 +439,7 @@ pub mod tests {
 
     lazy_static! {
         pub static ref USER_NAMESPACE: Namespace = Namespace {
-            collections: BTreeMap::from([("users".parse().unwrap(), USER_SCHEMA.clone())])
+            collections: BTreeMap::from([("users".to_string(), USER_SCHEMA.clone())])
         };
     }
 }

--- a/core/src/schema/namespace.rs
+++ b/core/src/schema/namespace.rs
@@ -57,13 +57,13 @@ impl Namespace {
     }
 
     #[inline]
-    pub fn iter(&self) -> impl Iterator<Item = (&String, &Content)> {
-        self.collections.iter()
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &Content)> {
+        self.collections.iter().map(|(k, v)| (k.as_str(), v))
     }
 
     #[inline]
-    pub fn keys(&self) -> impl Iterator<Item = &String> {
-        self.collections.keys()
+    pub fn keys(&self) -> impl Iterator<Item = &str> {
+        self.collections.keys().map(String::as_str)
     }
 
     pub fn default_try_update(&mut self, name: &str, value: &Value) -> Result<()> {
@@ -169,8 +169,8 @@ impl Compile for Namespace {
             .iter()
             .map(|(name, content)| {
                 compiler
-                    .build(name.as_ref(), content)
-                    .map(|graph| KeyValueOrNothing::always(name.as_ref(), graph, false))
+                    .build(name, content)
+                    .map(|graph| KeyValueOrNothing::always(name, graph, false))
             })
             .collect::<Result<_>>()?;
         Ok(Graph::Object(object_node))

--- a/core/src/schema/namespace.rs
+++ b/core/src/schema/namespace.rs
@@ -5,7 +5,6 @@ use crate::graph::prelude::OptionalMergeStrategy;
 use crate::graph::{Graph, KeyValueOrNothing};
 
 use std::collections::BTreeMap;
-use std::convert::AsRef;
 use std::{default::Default, iter::FromIterator};
 
 use anyhow::{Context, Result};
@@ -19,12 +18,6 @@ type JsonObject = Map<String, Value>;
 pub struct Namespace {
     #[serde(flatten)]
     collections: BTreeMap<String, Content>,
-}
-
-impl AsRef<BTreeMap<String, Content>> for Namespace {
-    fn as_ref(&self) -> &BTreeMap<String, Content> {
-        &self.collections
-    }
 }
 
 impl IntoIterator for Namespace {
@@ -110,6 +103,10 @@ impl Namespace {
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.collections.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.collections.len()
     }
 
     // May remove this in due course. Or add an only visible for testing flag

--- a/core/src/schema/namespace.rs
+++ b/core/src/schema/namespace.rs
@@ -1,5 +1,5 @@
 use super::inference::MergeStrategy;
-use super::{suggest_closest, ArrayContent, Content, FieldRef, Find};
+use super::{suggest_closest, Content, FieldRef, Find};
 use crate::compile::{Compile, Compiler};
 use crate::graph::prelude::OptionalMergeStrategy;
 use crate::graph::{Graph, KeyValueOrNothing};
@@ -100,17 +100,7 @@ impl Namespace {
     }
 
     pub fn put_collection_from_json(&mut self, name: String, value: &Value) -> Result<()> {
-        let as_content = Self::collection(value);
-        self.put_collection(name, as_content)?;
-        Ok(())
-    }
-
-    pub fn collection(value: &Value) -> Content {
-        // TODO: this function is confusing?! Rename and move?
-        Content::Array(ArrayContent {
-            length: Box::new(Content::from(&Value::from(1))),
-            content: Box::new(value.into()),
-        })
+        self.put_collection(name, Content::from_value_wrapped_in_array(value))
     }
 
     pub fn remove_collection(&mut self, name: &str) -> Option<Content> {

--- a/synth/src/cli/export.rs
+++ b/synth/src/cli/export.rs
@@ -13,7 +13,7 @@ use crate::cli::db_utils::DataSourceParams;
 use crate::datasource::DataSource;
 use crate::sampler::{Sampler, SamplerOutput};
 use async_std::task;
-use synth_core::{Name, Namespace, Value};
+use synth_core::{Namespace, Value};
 
 use super::collection_field_name_from_uri_query;
 
@@ -24,7 +24,7 @@ pub(crate) trait ExportStrategy {
 pub struct ExportParams {
     pub namespace: Namespace,
     /// The name of the single collection to generate from if one is specified (via --collection).
-    pub collection_name: Option<Name>,
+    pub collection_name: Option<String>,
     pub target: usize,
     pub seed: u64,
     pub ns_path: PathBuf,

--- a/synth/src/cli/import.rs
+++ b/synth/src/cli/import.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 
 use synth_core::schema::Namespace;
-use synth_core::{Content, Name};
+use synth_core::Content;
 
 use crate::cli::db_utils::DataSourceParams;
 use crate::cli::json::{JsonFileImportStrategy, JsonStdinImportStrategy};
@@ -21,7 +21,7 @@ pub trait ImportStrategy {
 
     /// Import a single collection. Default implementation works by calling `import` and then extracting from the
     /// returned namespace the correct collection based on the `name` parameter.
-    fn import_collection(&self, name: &Name) -> Result<Content> {
+    fn import_collection(&self, name: &str) -> Result<Content> {
         self.import()?
             .collections
             .remove(name)

--- a/synth/src/cli/import.rs
+++ b/synth/src/cli/import.rs
@@ -23,8 +23,7 @@ pub trait ImportStrategy {
     /// returned namespace the correct collection based on the `name` parameter.
     fn import_collection(&self, name: &str) -> Result<Content> {
         self.import()?
-            .collections
-            .remove(name)
+            .remove_collection(name)
             .ok_or_else(|| anyhow!("Could not find collection '{}'.", name))
     }
 }

--- a/synth/src/cli/import_utils.rs
+++ b/synth/src/cli/import_utils.rs
@@ -55,7 +55,7 @@ fn populate_namespace_collections<T: DataSource + RelationalDataSource>(
         let column_infos = task::block_on(datasource.get_columns_infos(table_name))?;
 
         namespace.put_collection(
-            table_name.clone(), // check table name is valid?
+            table_name.clone(),
             Collection::try_from((datasource, column_infos))?.collection,
         )?;
     }

--- a/synth/src/cli/import_utils.rs
+++ b/synth/src/cli/import_utils.rs
@@ -5,14 +5,13 @@ use async_std::task;
 use log::debug;
 use serde_json::Value;
 use std::convert::TryFrom;
-use std::str::FromStr;
 use synth_core::graph::json::synth_val_to_json;
 use synth_core::schema::content::number_content::U64;
 use synth_core::schema::{
     ArrayContent, FieldRef, NumberContent, ObjectContent, OptionalMergeStrategy, RangeStep,
     SameAsContent, UniqueContent,
 };
-use synth_core::{Content, Name, Namespace};
+use synth_core::{Content, Namespace};
 
 #[derive(Debug)]
 pub(crate) struct Collection {
@@ -56,7 +55,7 @@ fn populate_namespace_collections<T: DataSource + RelationalDataSource>(
         let column_infos = task::block_on(datasource.get_columns_infos(table_name))?;
 
         namespace.put_collection(
-            &Name::from_str(table_name)?,
+            table_name.clone(), // check table name is valid?
             Collection::try_from((datasource, column_infos))?.collection,
         )?;
     }
@@ -130,14 +129,10 @@ fn populate_namespace_values<T: DataSource + RelationalDataSource>(
 ) -> Result<()> {
     task::block_on(datasource.set_seed())?;
 
-    for table in table_names {
-        let values = task::block_on(datasource.get_deterministic_samples(table))?;
+    for table_name in table_names {
+        let values = task::block_on(datasource.get_deterministic_samples(table_name))?;
         let json_values: Vec<Value> = values.into_iter().map(synth_val_to_json).collect();
-        namespace.try_update(
-            OptionalMergeStrategy,
-            &Name::from_str(table).unwrap(),
-            &Value::from(json_values),
-        )?;
+        namespace.try_update(OptionalMergeStrategy, table_name, &Value::from(json_values))?;
     }
 
     Ok(())

--- a/synth/src/cli/json.rs
+++ b/synth/src/cli/json.rs
@@ -83,7 +83,7 @@ fn collection_from_value(value: &serde_json::Value) -> Result<Content> {
     match value {
         serde_json::Value::Array(values) => {
             let fst = values.first().unwrap_or(&serde_json::Value::Null);
-            let mut as_content = Namespace::collection(fst);
+            let mut as_content = Content::from_value_wrapped_in_array(fst);
             OptionalMergeStrategy.try_merge(&mut as_content, value)?;
             Ok(as_content)
         }

--- a/synth/src/cli/json.rs
+++ b/synth/src/cli/json.rs
@@ -68,7 +68,7 @@ pub fn import_json(val: serde_json::Value) -> Result<Namespace> {
             .into_iter()
             .map(|(name, value)| {
                 collection_from_value(&value)
-                    .and_then(|content| Ok((name.parse()?, content)))
+                    .map(|content| (name.clone(), content))
                     .with_context(|| anyhow!("While importing the collection `{}`", name))
             })
             .collect(),

--- a/synth/src/cli/jsonl.rs
+++ b/synth/src/cli/jsonl.rs
@@ -184,7 +184,7 @@ fn json_lines_from_sampler_output(
 /// collection.
 fn collection_from_values_jsonl(values: Vec<serde_json::Value>) -> Result<Content> {
     let fst = values.first().unwrap_or(&serde_json::Value::Null);
-    let mut as_content = Namespace::collection(fst);
+    let mut as_content = Content::from_value_wrapped_in_array(fst);
     OptionalMergeStrategy.try_merge(&mut as_content, &serde_json::Value::Array(values))?;
     Ok(as_content)
 }

--- a/synth/src/cli/mongo.rs
+++ b/synth/src/cli/mongo.rs
@@ -8,7 +8,6 @@ use mongodb::options::FindOptions;
 use mongodb::{bson::Document, options::ClientOptions, sync::Client};
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
-use std::str::FromStr;
 use synth_core::graph::prelude::content::number_content::U64;
 use synth_core::graph::prelude::number_content::I64;
 use synth_core::graph::prelude::{ChronoValue, Number, NumberContent, ObjectContent, RangeStep};
@@ -17,7 +16,7 @@ use synth_core::schema::{
     ArrayContent, BoolContent, Categorical, ChronoValueType, DateTimeContent, RegexContent,
     StringContent,
 };
-use synth_core::{Content, Name, Namespace, Value};
+use synth_core::{Content, Namespace, Value};
 
 #[derive(Clone, Debug)]
 pub struct MongoExportStrategy {
@@ -54,7 +53,7 @@ impl ImportStrategy for MongoImportStrategy {
                 let as_array = Content::Array(ArrayContent::from_content_default_length(
                     doc_to_content(&some_obj),
                 ));
-                namespace.put_collection(&Name::from_str(&collection_name)?, as_array)?;
+                namespace.put_collection(collection_name, as_array)?;
             } else {
                 info!("Collection {} is empty. Skipping...", collection_name);
                 continue;
@@ -79,10 +78,8 @@ impl ImportStrategy for MongoImportStrategy {
                 doc.remove("_id");
             });
 
-            namespace.default_try_update(
-                &Name::from_str(&collection_name)?,
-                &serde_json::to_value(random_sample)?,
-            )?;
+            namespace
+                .default_try_update(&collection_name, &serde_json::to_value(random_sample)?)?;
         }
 
         Ok(namespace)

--- a/synth/src/cli/store.rs
+++ b/synth/src/cli/store.rs
@@ -2,8 +2,7 @@ use anyhow::{Context, Result};
 use lazy_static::lazy_static;
 use std::fs::DirEntry;
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
-use synth_core::schema::{Content, Name, Namespace};
+use synth_core::schema::{Content, Namespace};
 
 lazy_static! {
     static ref UNDERLYING: Underlying = Underlying {
@@ -49,13 +48,13 @@ impl Store {
         self.path.join(namespace)
     }
 
-    pub fn relative_collection_path(namespace: &Path, collection: &Name) -> PathBuf {
+    pub fn relative_collection_path(namespace: &Path, collection: &str) -> PathBuf {
         namespace
-            .join(collection.to_string())
+            .join(collection)
             .with_extension(UNDERLYING.extension())
     }
 
-    fn collection_path(&self, namespace: &Path, collection: &Name) -> PathBuf {
+    fn collection_path(&self, namespace: &Path, collection: &str) -> PathBuf {
         self.path
             .join(Self::relative_collection_path(namespace, collection))
     }
@@ -64,7 +63,7 @@ impl Store {
         self.ns_path(namespace).exists()
     }
 
-    pub fn collection_exists(&self, namespace: &Path, collection: &Name) -> bool {
+    pub fn collection_exists(&self, namespace: &Path, collection: &str) -> bool {
         self.collection_path(namespace, collection).exists()
     }
 
@@ -82,7 +81,8 @@ impl Store {
                     let (collection_name, content) = self
                         .get_collection(&entry)
                         .with_context(|| anyhow!("at file {}", entry.path().display()))?;
-                    ns.put_collection(&collection_name, content)?;
+
+                    ns.put_collection(collection_name, content)?;
                 }
             }
         }
@@ -93,7 +93,7 @@ impl Store {
     pub fn save_collection_path(
         &self,
         ns_path: &Path,
-        collection: Name,
+        collection: String,
         content: Content,
     ) -> Result<()> {
         let abs_ns_path = self.ns_path(ns_path);
@@ -120,21 +120,24 @@ impl Store {
     /// Save a namespace given it's proper name.
     /// So will save to <store-dir>/<name>
     #[allow(unused)]
-    pub fn save_ns(&self, name: Name, namespace: Namespace) -> Result<()> {
-        let ns_path = self.path.join(name.to_string());
+    pub fn save_ns(&self, name: String, namespace: Namespace) -> Result<()> {
+        let ns_path = self.path.join(name);
         self.save_ns_path(ns_path, namespace)
     }
 
-    fn get_collection(&self, dir_entry: &DirEntry) -> Result<(Name, Content)> {
+    fn get_collection(&self, dir_entry: &DirEntry) -> Result<(String, Content)> {
         let entry_name = dir_entry.file_name();
         let file_name = entry_name.to_str().unwrap();
         let collection_name = file_name
             .split('.')
             .next()
-            .ok_or_else(|| failed!(target: Debug, "invalid filename {}", file_name))?;
+            .ok_or_else(|| failed!(target: Debug, "invalid filename {}", file_name))?
+            .to_string();
         let collection_file_content = std::fs::read_to_string(dir_entry.path())?;
         let collection = UNDERLYING.parse(&collection_file_content)?;
-        Ok((Name::from_str(collection_name)?, collection))
+
+        // TODO: Check collection name validity?
+        Ok((collection_name, collection))
     }
 }
 
@@ -148,7 +151,7 @@ pub mod tests {
         let path: PathBuf = tempdir().unwrap().path().into();
         let store = Store::with_dir(path.clone());
         let ns = Namespace::default();
-        let name = Name::from_str("users").unwrap();
+        let name = "users".to_string();
         store.save_ns(name, ns.clone())?;
 
         let saved_ns = store.get_ns(path.join("users"))?;

--- a/synth/src/cli/store.rs
+++ b/synth/src/cli/store.rs
@@ -136,7 +136,6 @@ impl Store {
         let collection_file_content = std::fs::read_to_string(dir_entry.path())?;
         let collection = UNDERLYING.parse(&collection_file_content)?;
 
-        // TODO: Check collection name validity?
         Ok((collection_name, collection))
     }
 }

--- a/synth/src/cli/telemetry.rs
+++ b/synth/src/cli/telemetry.rs
@@ -22,7 +22,7 @@ use crate::version::version;
 
 use synth_core::{
     compile::{Address, CompilerState, FromLink, Source},
-    Compile, Compiler, Content, Graph, Name, Namespace,
+    Compile, Compiler, Content, Graph, Namespace,
 };
 
 use super::{Args, TelemetryCommand};
@@ -215,7 +215,7 @@ impl TelemetryExportStrategy {
     pub(super) fn fill_telemetry_pre(
         context: Rc<RefCell<TelemetryContext>>,
         namespace: &Namespace,
-        collection: Option<Name>,
+        collection: Option<String>,
         ns_path: PathBuf,
     ) -> Result<()> {
         let crawler = TelemetryCrawler {

--- a/synth/src/cli/telemetry.rs
+++ b/synth/src/cli/telemetry.rs
@@ -225,7 +225,7 @@ impl TelemetryExportStrategy {
         };
 
         if let Some(name) = collection {
-            if let Some(content) = namespace.as_ref().get(&name) {
+            if let Ok(content) = namespace.get_collection(&name) {
                 content.compile(crawler)?;
                 context.borrow_mut().num_collections = Some(1);
 
@@ -236,7 +236,7 @@ impl TelemetryExportStrategy {
             }
         } else {
             namespace.compile(crawler)?;
-            let num_col = namespace.as_ref().len();
+            let num_col = namespace.len();
             context.borrow_mut().num_collections = Some(num_col);
 
             // Namespace, length and content for each collection

--- a/synth/src/cli/telemetry.rs
+++ b/synth/src/cli/telemetry.rs
@@ -225,7 +225,7 @@ impl TelemetryExportStrategy {
         };
 
         if let Some(name) = collection {
-            if let Some(content) = namespace.collections.get(&name) {
+            if let Some(content) = namespace.as_ref().get(&name) {
                 content.compile(crawler)?;
                 context.borrow_mut().num_collections = Some(1);
 
@@ -236,7 +236,7 @@ impl TelemetryExportStrategy {
             }
         } else {
             namespace.compile(crawler)?;
-            let num_col = namespace.collections.len();
+            let num_col = namespace.as_ref().len();
             context.borrow_mut().num_collections = Some(num_col);
 
             // Namespace, length and content for each collection


### PR DESCRIPTION
Removes the `schema::Name` struct entirely. Use regular `String` instead, with necessary checks in place to prevent invalid names. Also made some minor changes to `Namespace` to make it a little bit nicer to work with.

Minor issue: potentially invalid names could be put into a `Namespace` due to the fact that it implements `FromIterator` - I'm not aware of a fallible version of that trait that could be used instead?