### PR TITLE
refactor: datasource

### DIFF
--- a/synth/build.rs
+++ b/synth/build.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     let mut f = File::create(format!("{}/meta.rs", env::var("OUT_DIR").unwrap()))?;
     write!(
-        &mut f,
+        f,
         r#"#[allow(dead_code)] pub const META_OID: &str = "{}";
         #[allow(dead_code)] pub const META_SHORTNAME: &str = "{}";
         #[allow(dead_code)] pub const META_OS: &str = "{}";

--- a/synth/src/cli/import_utils.rs
+++ b/synth/src/cli/import_utils.rs
@@ -77,7 +77,7 @@ where
     Ok(table_names)
 }
 
-fn populate_namespace_collections<T: DataSource + RelationalDataSource>(
+fn populate_namespace_collections<T: DataSource + RelationalDataSource + SqlxDataSource>(
     namespace: &mut Namespace,
     table_names: &[String],
     datasource: &T,
@@ -258,7 +258,7 @@ where
         .collect()
 }
 
-impl<T: RelationalDataSource + DataSource> TryFrom<(&T, Vec<ColumnInfo>)> for Collection {
+impl<T: SqlxDataSource> TryFrom<(&T, Vec<ColumnInfo>)> for Collection {
     type Error = anyhow::Error;
 
     fn try_from(columns_meta: (&T, Vec<ColumnInfo>)) -> Result<Self> {
@@ -283,7 +283,7 @@ impl<T: RelationalDataSource + DataSource> TryFrom<(&T, Vec<ColumnInfo>)> for Co
     }
 }
 
-impl<T: RelationalDataSource + DataSource> TryFrom<(&T, &ColumnInfo)> for FieldContentWrapper {
+impl<T: SqlxDataSource> TryFrom<(&T, &ColumnInfo)> for FieldContentWrapper {
     type Error = anyhow::Error;
 
     fn try_from(column_meta: (&T, &ColumnInfo)) -> Result<Self> {

--- a/synth/src/cli/import_utils.rs
+++ b/synth/src/cli/import_utils.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use async_std::task;
 use log::debug;
 use serde_json::Value;
-use sqlx::{Database, Executor, Row};
+use sqlx::{Executor, Row};
 use std::convert::TryFrom;
 use synth_core::graph::json::synth_val_to_json;
 use synth_core::schema::content::number_content::U64;
@@ -29,7 +29,7 @@ pub(crate) fn build_namespace_import<T: DataSource + SqlxDataSource>(
 ) -> Result<Namespace>
 where
     T: Sync,
-    for<'c> &'c mut <T::DB as Database>::Connection: Executor<'c, Database = T::DB>,
+    for<'c> &'c mut T::Connection: Executor<'c, Database = T::DB>,
     String: sqlx::Type<T::DB>,
     for<'d> String: sqlx::Decode<'d, T::DB> + sqlx::Encode<'d, T::DB>,
     usize: sqlx::ColumnIndex<<T::DB as sqlx::Database>::Row>,
@@ -60,7 +60,7 @@ where
 
 async fn get_table_names<T: SqlxDataSource>(datasource: &T) -> Result<Vec<String>>
 where
-    for<'c> &'c mut <T::DB as Database>::Connection: Executor<'c, Database = T::DB>,
+    for<'c> &'c mut T::Connection: Executor<'c, Database = T::DB>,
     String: sqlx::Type<T::DB>,
     for<'d> String: sqlx::Decode<'d, T::DB>,
     usize: sqlx::ColumnIndex<<T::DB as sqlx::Database>::Row>,
@@ -84,7 +84,7 @@ fn populate_namespace_collections<T: DataSource + SqlxDataSource>(
     datasource: &T,
 ) -> Result<()>
 where
-    for<'c> &'c mut <T::DB as Database>::Connection: Executor<'c, Database = T::DB>,
+    for<'c> &'c mut T::Connection: Executor<'c, Database = T::DB>,
     String: sqlx::Type<T::DB>,
     for<'d> String: sqlx::Encode<'d, T::DB>,
     ColumnInfo: TryFrom<<T::DB as sqlx::Database>::Row, Error = anyhow::Error>,
@@ -109,7 +109,7 @@ fn populate_namespace_primary_keys<T: DataSource + SqlxDataSource>(
     datasource: &T,
 ) -> Result<()>
 where
-    for<'c> &'c mut <T::DB as Database>::Connection: Executor<'c, Database = T::DB>,
+    for<'c> &'c mut T::Connection: Executor<'c, Database = T::DB>,
     String: sqlx::Type<T::DB>,
     for<'d> String: sqlx::Encode<'d, T::DB>,
     PrimaryKey: TryFrom<<T::DB as sqlx::Database>::Row, Error = anyhow::Error>,
@@ -155,7 +155,7 @@ async fn get_primary_keys<T: SqlxDataSource>(
     table_name: String,
 ) -> Result<Vec<PrimaryKey>>
 where
-    for<'c> &'c mut <T::DB as Database>::Connection: Executor<'c, Database = T::DB>,
+    for<'c> &'c mut T::Connection: Executor<'c, Database = T::DB>,
     String: sqlx::Type<T::DB>,
     for<'d> String: sqlx::Encode<'d, T::DB>,
     PrimaryKey: TryFrom<<T::DB as sqlx::Database>::Row, Error = anyhow::Error>,
@@ -178,7 +178,7 @@ fn populate_namespace_foreign_keys<T: DataSource + SqlxDataSource>(
     datasource: &T,
 ) -> Result<()>
 where
-    for<'c> &'c mut <T::DB as Database>::Connection: Executor<'c, Database = T::DB>,
+    for<'c> &'c mut T::Connection: Executor<'c, Database = T::DB>,
     ForeignKey: TryFrom<<T::DB as sqlx::Database>::Row, Error = anyhow::Error>,
 {
     let foreign_keys = task::block_on(get_foreign_keys(datasource))?;
@@ -197,7 +197,7 @@ where
 
 async fn get_foreign_keys<T: SqlxDataSource>(datasource: &T) -> Result<Vec<ForeignKey>>
 where
-    for<'c> &'c mut <T::DB as Database>::Connection: Executor<'c, Database = T::DB>,
+    for<'c> &'c mut T::Connection: Executor<'c, Database = T::DB>,
     ForeignKey: TryFrom<<T::DB as sqlx::Database>::Row, Error = anyhow::Error>,
 {
     let query = datasource.get_foreign_keys_query();
@@ -219,7 +219,7 @@ fn populate_namespace_values<T: DataSource + SqlxDataSource>(
 ) -> Result<()>
 where
     T: Sync,
-    for<'c> &'c mut <T::DB as Database>::Connection: Executor<'c, Database = T::DB>,
+    for<'c> &'c mut T::Connection: Executor<'c, Database = T::DB>,
     String: sqlx::Type<T::DB>,
     for<'d> String: sqlx::Encode<'d, T::DB>,
     ValueWrapper: TryFrom<<T::DB as sqlx::Database>::Row, Error = anyhow::Error>,
@@ -243,7 +243,7 @@ async fn get_deterministic_samples<T: SqlxDataSource>(
     table: String,
 ) -> Result<Vec<synth_core::Value>>
 where
-    for<'c> &'c mut <T::DB as Database>::Connection: Executor<'c, Database = T::DB>,
+    for<'c> &'c mut T::Connection: Executor<'c, Database = T::DB>,
     ValueWrapper: TryFrom<<T::DB as sqlx::Database>::Row, Error = anyhow::Error>,
 {
     let query = datasource.get_deterministic_samples_query(table);

--- a/synth/src/cli/import_utils.rs
+++ b/synth/src/cli/import_utils.rs
@@ -78,7 +78,7 @@ where
     Ok(table_names)
 }
 
-fn populate_namespace_collections<T: DataSource + SqlxDataSource>(
+fn populate_namespace_collections<T: SqlxDataSource>(
     namespace: &mut Namespace,
     table_names: &[String],
     datasource: &T,
@@ -103,7 +103,7 @@ where
     Ok(())
 }
 
-fn populate_namespace_primary_keys<T: DataSource + SqlxDataSource>(
+fn populate_namespace_primary_keys<T: SqlxDataSource>(
     namespace: &mut Namespace,
     table_names: &[String],
     datasource: &T,
@@ -173,7 +173,7 @@ where
         .collect()
 }
 
-fn populate_namespace_foreign_keys<T: DataSource + SqlxDataSource>(
+fn populate_namespace_foreign_keys<T: SqlxDataSource>(
     namespace: &mut Namespace,
     datasource: &T,
 ) -> Result<()>
@@ -212,7 +212,7 @@ where
         .collect()
 }
 
-fn populate_namespace_values<T: DataSource + SqlxDataSource>(
+fn populate_namespace_values<T: SqlxDataSource>(
     namespace: &mut Namespace,
     table_names: &[String],
     datasource: &T,

--- a/synth/src/datasource/mysql_datasource.rs
+++ b/synth/src/datasource/mysql_datasource.rs
@@ -173,23 +173,6 @@ impl RelationalDataSource for MySqlDataSource {
             .map(ColumnInfo::try_from)
             .collect()
     }
-
-    fn extend_parameterised_query(
-        query: &mut String,
-        _curr_index: usize,
-        query_params: Vec<Value>,
-    ) {
-        let extend = query_params.len();
-
-        query.push('(');
-        for i in 0..extend {
-            query.push('?');
-            if i != extend - 1 {
-                query.push(',');
-            }
-        }
-        query.push(')');
-    }
 }
 
 impl TryFrom<MySqlRow> for ColumnInfo {

--- a/synth/src/datasource/mysql_datasource.rs
+++ b/synth/src/datasource/mysql_datasource.rs
@@ -136,6 +136,13 @@ impl SqlxDataSource for MySqlDataSource {
 
         Ok(content)
     }
+
+    fn get_columns_info_query(&self) -> &str {
+        r"SELECT column_name, ordinal_position, is_nullable, data_type,
+            character_maximum_length
+            FROM information_schema.columns
+            WHERE table_name = ? AND table_schema = DATABASE()"
+    }
 }
 
 #[async_trait]
@@ -157,21 +164,6 @@ impl RelationalDataSource for MySqlDataSource {
         let result = query.execute(&self.pool).await?;
 
         Ok(result)
-    }
-
-    async fn get_columns_infos(&self, table_name: &str) -> Result<Vec<ColumnInfo>> {
-        let query = r"SELECT column_name, ordinal_position, is_nullable, data_type,
-            character_maximum_length
-            FROM information_schema.columns
-            WHERE table_name = ? AND table_schema = DATABASE()";
-
-        sqlx::query(query)
-            .bind(table_name)
-            .fetch_all(&self.pool)
-            .await?
-            .into_iter()
-            .map(ColumnInfo::try_from)
-            .collect()
     }
 }
 

--- a/synth/src/datasource/mysql_datasource.rs
+++ b/synth/src/datasource/mysql_datasource.rs
@@ -85,43 +85,6 @@ impl SqlxDataSource for MySqlDataSource {
     fn get_deterministic_samples_query(&self, table_name: String) -> String {
         format!("SELECT * FROM {} ORDER BY rand(0.5) LIMIT 10", table_name)
     }
-}
-
-#[async_trait]
-impl RelationalDataSource for MySqlDataSource {
-    type QueryResult = MySqlQueryResult;
-    const IDENTIFIER_QUOTE: char = '`';
-
-    async fn execute_query(
-        &self,
-        query: String,
-        query_params: Vec<Value>,
-    ) -> Result<MySqlQueryResult> {
-        let mut query = sqlx::query(query.as_str());
-
-        for param in query_params {
-            query = query.bind(param);
-        }
-
-        let result = query.execute(&self.pool).await?;
-
-        Ok(result)
-    }
-
-    async fn get_columns_infos(&self, table_name: &str) -> Result<Vec<ColumnInfo>> {
-        let query = r"SELECT column_name, ordinal_position, is_nullable, data_type,
-            character_maximum_length
-            FROM information_schema.columns
-            WHERE table_name = ? AND table_schema = DATABASE()";
-
-        sqlx::query(query)
-            .bind(table_name)
-            .fetch_all(&self.pool)
-            .await?
-            .into_iter()
-            .map(ColumnInfo::try_from)
-            .collect()
-    }
 
     fn decode_to_content(&self, column_info: &ColumnInfo) -> Result<Content> {
         let content = match column_info.data_type.to_lowercase().as_str() {
@@ -172,6 +135,43 @@ impl RelationalDataSource for MySqlDataSource {
         };
 
         Ok(content)
+    }
+}
+
+#[async_trait]
+impl RelationalDataSource for MySqlDataSource {
+    type QueryResult = MySqlQueryResult;
+    const IDENTIFIER_QUOTE: char = '`';
+
+    async fn execute_query(
+        &self,
+        query: String,
+        query_params: Vec<Value>,
+    ) -> Result<MySqlQueryResult> {
+        let mut query = sqlx::query(query.as_str());
+
+        for param in query_params {
+            query = query.bind(param);
+        }
+
+        let result = query.execute(&self.pool).await?;
+
+        Ok(result)
+    }
+
+    async fn get_columns_infos(&self, table_name: &str) -> Result<Vec<ColumnInfo>> {
+        let query = r"SELECT column_name, ordinal_position, is_nullable, data_type,
+            character_maximum_length
+            FROM information_schema.columns
+            WHERE table_name = ? AND table_schema = DATABASE()";
+
+        sqlx::query(query)
+            .bind(table_name)
+            .fetch_all(&self.pool)
+            .await?
+            .into_iter()
+            .map(ColumnInfo::try_from)
+            .collect()
     }
 
     fn extend_parameterised_query(

--- a/synth/src/datasource/mysql_datasource.rs
+++ b/synth/src/datasource/mysql_datasource.rs
@@ -118,11 +118,6 @@ impl RelationalDataSource for MySqlDataSource {
             .collect()
     }
 
-    async fn set_seed(&self) -> Result<()> {
-        // MySql doesn't set seed in a separate query
-        Ok(())
-    }
-
     async fn get_deterministic_samples(&self, table_name: &str) -> Result<Vec<Value>> {
         let query = format!("SELECT * FROM {} ORDER BY rand(0.5) LIMIT 10", table_name);
 

--- a/synth/src/datasource/mysql_datasource.rs
+++ b/synth/src/datasource/mysql_datasource.rs
@@ -63,10 +63,6 @@ impl SqlxDataSource for MySqlDataSource {
         Pool::clone(&self.pool)
     }
 
-    fn query<'q>(&self, query: &'q str) -> sqlx::query::Query<'q, Self::DB, Self::Arguments> {
-        sqlx::query(query)
-    }
-
     fn get_table_names_query(&self) -> &str {
         r"SELECT table_name FROM information_schema.tables
             WHERE table_schema = DATABASE() and table_type = 'BASE TABLE'"

--- a/synth/src/datasource/relational_datasource.rs
+++ b/synth/src/datasource/relational_datasource.rs
@@ -40,6 +40,7 @@ pub struct ForeignKey {
 #[derive(Debug)]
 pub struct ValueWrapper(pub(crate) Value);
 
+#[async_trait]
 pub trait SqlxDataSource<'q>: DataSource {
     type DB: Database + HasArguments<'q>;
 
@@ -60,6 +61,11 @@ pub trait SqlxDataSource<'q>: DataSource {
 
     /// Get query for foreign keys
     fn get_foreign_keys_query(&self) -> &'q str;
+
+    async fn set_seed(&self) -> Result<()> {
+        // Default for sources that don't need to set a seed
+        Ok(())
+    }
 }
 
 /// All relational databases should define this trait and implement database specific queries in
@@ -178,8 +184,6 @@ pub trait RelationalDataSource: DataSource {
     ) -> Result<Self::QueryResult>;
 
     async fn get_columns_infos(&self, table_name: &str) -> Result<Vec<ColumnInfo>>;
-
-    async fn set_seed(&self) -> Result<()>;
 
     async fn get_deterministic_samples(&self, table_name: &str) -> Result<Vec<Value>>;
 

--- a/synth/src/datasource/relational_datasource.rs
+++ b/synth/src/datasource/relational_datasource.rs
@@ -54,6 +54,9 @@ pub trait SqlxDataSource<'q>: DataSource {
 
     /// Get query for table names
     fn get_table_names_query(&self) -> &'q str;
+
+    /// Get query for primary keys
+    fn get_primary_keys_query(&self) -> &'q str;
 }
 
 /// All relational databases should define this trait and implement database specific queries in
@@ -172,8 +175,6 @@ pub trait RelationalDataSource: DataSource {
     ) -> Result<Self::QueryResult>;
 
     async fn get_columns_infos(&self, table_name: &str) -> Result<Vec<ColumnInfo>>;
-
-    async fn get_primary_keys(&self, table_name: &str) -> Result<Vec<PrimaryKey>>;
 
     async fn get_foreign_keys(&self) -> Result<Vec<ForeignKey>>;
 

--- a/synth/src/datasource/relational_datasource.rs
+++ b/synth/src/datasource/relational_datasource.rs
@@ -87,17 +87,20 @@ pub trait SqlxDataSource: DataSource {
     /// Decodes column to our Content
     fn decode_to_content(&self, column_info: &ColumnInfo) -> Result<Content>;
 
+    /// Get the function arguments for datasource
+    fn get_function_argument_placeholder(_current: usize, _index: usize, _value: &Value) -> String {
+        "?".to_string()
+    }
+
     // Returns extended query string + current index
-    fn extend_parameterised_query(
-        query: &mut String,
-        _curr_index: usize,
-        query_params: Vec<Value>,
-    ) {
+    fn extend_parameterised_query(query: &mut String, curr_index: usize, query_params: Vec<Value>) {
         let extend = query_params.len();
 
         query.push('(');
-        for i in 0..extend {
-            query.push('?');
+        for (i, param) in query_params.iter().enumerate() {
+            query.push_str(&Self::get_function_argument_placeholder(
+                curr_index, i, param,
+            ));
             if i != extend - 1 {
                 query.push(',');
             }

--- a/synth/src/datasource/relational_datasource.rs
+++ b/synth/src/datasource/relational_datasource.rs
@@ -67,6 +67,9 @@ pub trait SqlxDataSource: DataSource {
 
     /// Get query for deterministic values
     fn get_deterministic_samples_query(&self, table_name: String) -> String;
+
+    /// Decodes column to our Content
+    fn decode_to_content(&self, column_info: &ColumnInfo) -> Result<Content>;
 }
 
 /// All relational databases should define this trait and implement database specific queries in
@@ -185,8 +188,6 @@ pub trait RelationalDataSource: DataSource {
     ) -> Result<Self::QueryResult>;
 
     async fn get_columns_infos(&self, table_name: &str) -> Result<Vec<ColumnInfo>>;
-
-    fn decode_to_content(&self, column_info: &ColumnInfo) -> Result<Content>;
 
     // Returns extended query string + current index
     fn extend_parameterised_query(query: &mut String, curr_index: usize, query_params: Vec<Value>);

--- a/synth/src/datasource/relational_datasource.rs
+++ b/synth/src/datasource/relational_datasource.rs
@@ -43,6 +43,8 @@ pub struct ForeignKey {
 #[derive(Debug)]
 pub struct ValueWrapper(pub(crate) Value);
 
+/// All sqlx databases should define this trait and implement database specific queries in
+/// their own implementations.
 #[async_trait]
 pub trait SqlxDataSource: DataSource {
     type DB: Database<Arguments = Self::Arguments, Connection = Self::Connection>;
@@ -58,7 +60,9 @@ pub trait SqlxDataSource: DataSource {
     fn get_multithread_pool(&self) -> Pool<Self::DB>;
 
     /// Prepare a single query with data source specifics
-    fn query<'q>(&self, query: &'q str) -> Query<'q, Self::DB, Self::Arguments>;
+    fn query<'q>(&self, query: &'q str) -> Query<'q, Self::DB, Self::Arguments> {
+        sqlx::query(query)
+    }
 
     /// Get query for table names
     fn get_table_names_query(&self) -> &str;

--- a/synth/src/datasource/relational_datasource.rs
+++ b/synth/src/datasource/relational_datasource.rs
@@ -57,6 +57,9 @@ pub trait SqlxDataSource<'q>: DataSource {
 
     /// Get query for primary keys
     fn get_primary_keys_query(&self) -> &'q str;
+
+    /// Get query for foreign keys
+    fn get_foreign_keys_query(&self) -> &'q str;
 }
 
 /// All relational databases should define this trait and implement database specific queries in
@@ -175,8 +178,6 @@ pub trait RelationalDataSource: DataSource {
     ) -> Result<Self::QueryResult>;
 
     async fn get_columns_infos(&self, table_name: &str) -> Result<Vec<ColumnInfo>>;
-
-    async fn get_foreign_keys(&self) -> Result<Vec<ForeignKey>>;
 
     async fn set_seed(&self) -> Result<()>;
 

--- a/synth/src/datasource/relational_datasource.rs
+++ b/synth/src/datasource/relational_datasource.rs
@@ -49,6 +49,8 @@ pub trait SqlxDataSource: DataSource {
     type Arguments: for<'q> Arguments<'q, Database = Self::DB> + for<'q> IntoArguments<'q, Self::DB>;
     type Connection: Connection<Database = Self::DB>;
 
+    const IDENTIFIER_QUOTE: char;
+
     /// Gets a pool to execute queries with
     fn get_pool(&self) -> Pool<Self::DB>;
 
@@ -121,121 +123,112 @@ pub trait SqlxDataSource: DataSource {
     }
 }
 
-/// All relational databases should define this trait and implement database specific queries in
-/// their own impl. APIs should be defined async when possible, delegating to the caller on how to
-/// handle it.
-#[async_trait]
-pub trait RelationalDataSource: DataSource + SqlxDataSource
+pub async fn insert_relational_data<T: SqlxDataSource + Sync>(
+    datasource: &T,
+    collection_name: &str,
+    collection: &[Value],
+) -> Result<()>
 where
-    Self: Sized,
-    for<'c> &'c mut Self::Connection: Executor<'c, Database = Self::DB>,
-    String: sqlx::Type<Self::DB>,
-    for<'d> String: sqlx::Encode<'d, Self::DB>,
-    ColumnInfo: TryFrom<<Self::DB as sqlx::Database>::Row, Error = anyhow::Error>,
-    Value: Type<Self::DB>,
-    for<'d> Value: Encode<'d, Self::DB>,
+    for<'c> &'c mut T::Connection: Executor<'c, Database = T::DB>,
+    String: Type<T::DB>,
+    for<'d> String: Encode<'d, T::DB>,
+    ColumnInfo: TryFrom<<T::DB as Database>::Row, Error = anyhow::Error>,
+    Value: Type<T::DB>,
+    for<'d> Value: Encode<'d, T::DB>,
 {
-    const IDENTIFIER_QUOTE: char;
+    let batch_size = DEFAULT_INSERT_BATCH_SIZE;
 
-    async fn insert_relational_data(
-        &self,
-        collection_name: &str,
-        collection: &[Value],
-    ) -> Result<()> {
-        let batch_size = DEFAULT_INSERT_BATCH_SIZE;
-
-        if collection.is_empty() {
-            println!(
-                "Collection {} generated 0 values. Skipping insertion...",
-                collection_name
-            );
-            return Ok(());
-        }
-
-        let column_infos = get_columns_info(self, collection_name.to_string()).await?;
-        let first_valueset = collection[0]
-            .as_object()
-            .expect("This is always an object (sampler contract)");
-
-        for column_info in column_infos {
-            if let Some(value) = first_valueset.get(&column_info.column_name) {
-                match (value, &*column_info.data_type) {
-                    (
-                        Value::Number(Number::U64(_)),
-                        "int2" | "int4" | "int8" | "smallint" | "int" | "bigint",
-                    ) => warn!(
-                        "Trying to put an unsigned u64 into a {} typed column {}.{}",
-                        column_info.data_type, collection_name, column_info.column_name
-                    ),
-                    (
-                        Value::Number(Number::U32(_)),
-                        "int2" | "int4" | "int8" | "smallint" | "int" | "bigint",
-                    ) => warn!(
-                        "Trying to put an unsigned u32 into a {} typed column {}.{}",
-                        column_info.data_type, collection_name, column_info.column_name
-                    ),
-                    (Value::Number(Number::I64(_)), "int2" | "int4" | "smallint" | "int") => warn!(
-                        "Trying to put a signed i64 into a {} typed column {}.{}",
-                        column_info.data_type, collection_name, column_info.column_name
-                    ),
-                    (Value::Number(Number::I32(_)), "int2" | "int8" | "smallint" | "bigint") => {
-                        warn!(
-                            "Trying to put a signed i32 into a {} typed column {}.{}",
-                            column_info.data_type, collection_name, column_info.column_name
-                        )
-                    }
-                    //TODO: More variants
-                    _ => {}
-                }
-            }
-        }
-
-        let column_names = first_valueset
-            .keys()
-            .map(|k| format!("{}{}{}", Self::IDENTIFIER_QUOTE, k, Self::IDENTIFIER_QUOTE))
-            .collect::<Vec<String>>()
-            .join(",");
-
-        let mut futures = Vec::with_capacity(collection.len());
-
-        for rows in collection.chunks(batch_size) {
-            let mut query = format!(
-                "INSERT INTO {} ({}) VALUES \n",
-                collection_name, column_names
-            );
-
-            let mut curr_index = 0;
-            let mut query_params = vec![];
-
-            for (i, row) in rows.iter().enumerate() {
-                let row_obj = row
-                    .as_object()
-                    .expect("This is always an object (sampler contract)");
-
-                let mut curr_query_params: Vec<Value> = row_obj.values().cloned().collect();
-                Self::extend_parameterised_query(&mut query, curr_index, curr_query_params.clone());
-                curr_index += curr_query_params.len();
-                query_params.append(&mut curr_query_params);
-
-                if i == rows.len() - 1 {
-                    query.push_str(";\n");
-                } else {
-                    query.push_str(",\n");
-                }
-            }
-            let future = self.execute_query(query, query_params);
-            futures.push(future);
-        }
-
-        let results = join_all(futures).await;
-
-        if let Err(e) = results.into_iter().bcollect::<Vec<_>>() {
-            bail!("One or more database inserts failed: {:?}", e)
-        }
-
-        info!("Inserted {} rows...", collection.len());
-        Ok(())
+    if collection.is_empty() {
+        println!(
+            "Collection {} generated 0 values. Skipping insertion...",
+            collection_name
+        );
+        return Ok(());
     }
+
+    let column_infos = get_columns_info(datasource, collection_name.to_string()).await?;
+    let first_valueset = collection[0]
+        .as_object()
+        .expect("This is always an object (sampler contract)");
+
+    for column_info in column_infos {
+        if let Some(value) = first_valueset.get(&column_info.column_name) {
+            match (value, &*column_info.data_type) {
+                (
+                    Value::Number(Number::U64(_)),
+                    "int2" | "int4" | "int8" | "smallint" | "int" | "bigint",
+                ) => warn!(
+                    "Trying to put an unsigned u64 into a {} typed column {}.{}",
+                    column_info.data_type, collection_name, column_info.column_name
+                ),
+                (
+                    Value::Number(Number::U32(_)),
+                    "int2" | "int4" | "int8" | "smallint" | "int" | "bigint",
+                ) => warn!(
+                    "Trying to put an unsigned u32 into a {} typed column {}.{}",
+                    column_info.data_type, collection_name, column_info.column_name
+                ),
+                (Value::Number(Number::I64(_)), "int2" | "int4" | "smallint" | "int") => warn!(
+                    "Trying to put a signed i64 into a {} typed column {}.{}",
+                    column_info.data_type, collection_name, column_info.column_name
+                ),
+                (Value::Number(Number::I32(_)), "int2" | "int8" | "smallint" | "bigint") => {
+                    warn!(
+                        "Trying to put a signed i32 into a {} typed column {}.{}",
+                        column_info.data_type, collection_name, column_info.column_name
+                    )
+                }
+                //TODO: More variants
+                _ => {}
+            }
+        }
+    }
+
+    let column_names = first_valueset
+        .keys()
+        .map(|k| format!("{}{}{}", T::IDENTIFIER_QUOTE, k, T::IDENTIFIER_QUOTE))
+        .collect::<Vec<String>>()
+        .join(",");
+
+    let mut futures = Vec::with_capacity(collection.len());
+
+    for rows in collection.chunks(batch_size) {
+        let mut query = format!(
+            "INSERT INTO {} ({}) VALUES \n",
+            collection_name, column_names
+        );
+
+        let mut curr_index = 0;
+        let mut query_params = vec![];
+
+        for (i, row) in rows.iter().enumerate() {
+            let row_obj = row
+                .as_object()
+                .expect("This is always an object (sampler contract)");
+
+            let mut curr_query_params: Vec<Value> = row_obj.values().cloned().collect();
+            T::extend_parameterised_query(&mut query, curr_index, curr_query_params.clone());
+            curr_index += curr_query_params.len();
+            query_params.append(&mut curr_query_params);
+
+            if i == rows.len() - 1 {
+                query.push_str(";\n");
+            } else {
+                query.push_str(",\n");
+            }
+        }
+        let future = datasource.execute_query(query, query_params);
+        futures.push(future);
+    }
+
+    let results = join_all(futures).await;
+
+    if let Err(e) = results.into_iter().bcollect::<Vec<_>>() {
+        bail!("One or more database inserts failed: {:?}", e)
+    }
+
+    info!("Inserted {} rows...", collection.len());
+    Ok(())
 }
 
 pub async fn get_columns_info<T: SqlxDataSource>(
@@ -244,9 +237,9 @@ pub async fn get_columns_info<T: SqlxDataSource>(
 ) -> Result<Vec<ColumnInfo>>
 where
     for<'c> &'c mut T::Connection: Executor<'c, Database = T::DB>,
-    String: sqlx::Type<T::DB>,
-    for<'d> String: sqlx::Encode<'d, T::DB>,
-    ColumnInfo: TryFrom<<T::DB as sqlx::Database>::Row, Error = anyhow::Error>,
+    String: Type<T::DB>,
+    for<'d> String: Encode<'d, T::DB>,
+    ColumnInfo: TryFrom<<T::DB as Database>::Row, Error = anyhow::Error>,
 {
     let query = datasource.get_columns_info_query();
     let pool = datasource.get_pool();


### PR DESCRIPTION
This reworks `RelationalDataSource` to make it easier to implement sqlx datasources in the future with less code duplication. Born from the #187 discussion 