### PR TITLE
refactor: e2e testing

### DIFF
--- a/synth/testing_harness/mongodb/e2e.sh
+++ b/synth/testing_harness/mongodb/e2e.sh
@@ -11,7 +11,7 @@ then
 fi
 
 SYNTH="synth"
-[ "${CI-false}" == "true" ] || SYNTH="cargo run --bin synth"
+[ "${CI-false}" == "true" ] || SYNTH="cargo run --quiet --bin synth"
 
 COLLECTIONS=(hospitals doctors patients)
 

--- a/synth/testing_harness/mongodb/e2e.sh
+++ b/synth/testing_harness/mongodb/e2e.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -uo pipefail
 

--- a/synth/testing_harness/mongodb/e2e.sh
+++ b/synth/testing_harness/mongodb/e2e.sh
@@ -109,6 +109,7 @@ function up() {
 function down() {
   echo -e "${DEBUG}Stopping container${NC}"
   docker stop $NAME > /dev/null
+  docker rm $NAME > /dev/null
 }
 
 function cleanup() {

--- a/synth/testing_harness/mysql/e2e.sh
+++ b/synth/testing_harness/mysql/e2e.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -uo pipefail
 

--- a/synth/testing_harness/mysql/e2e.sh
+++ b/synth/testing_harness/mysql/e2e.sh
@@ -88,6 +88,7 @@ function up() {
 function down() {
   echo -e "${DEBUG}Stopping container${NC}"
   docker stop $NAME > /dev/null
+  docker rm $NAME > /dev/null
 }
 
 function cleanup() {

--- a/synth/testing_harness/mysql/e2e.sh
+++ b/synth/testing_harness/mysql/e2e.sh
@@ -11,7 +11,7 @@ then
 fi
 
 SYNTH="synth"
-[ "${CI-false}" == "true" ] || SYNTH="cargo run --bin synth"
+[ "${CI-false}" == "true" ] || SYNTH="cargo run --quiet --bin synth"
 
 ERROR='\033[0;31m'
 INFO='\033[0;36m'

--- a/synth/testing_harness/postgres/e2e.sh
+++ b/synth/testing_harness/postgres/e2e.sh
@@ -108,6 +108,7 @@ function up() {
 function down() {
   echo -e "${DEBUG}Stopping container${NC}"
   docker stop $NAME > /dev/null
+  docker rm $NAME > /dev/null
 }
 
 function cleanup() {

--- a/synth/testing_harness/postgres/e2e.sh
+++ b/synth/testing_harness/postgres/e2e.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -uo pipefail
 

--- a/synth/testing_harness/postgres/e2e.sh
+++ b/synth/testing_harness/postgres/e2e.sh
@@ -11,7 +11,7 @@ then
 fi
 
 SYNTH="synth"
-[ "${CI-false}" == "true" ] || SYNTH="cargo run --bin synth"
+[ "${CI-false}" == "true" ] || SYNTH="cargo run --quiet --bin synth"
 
 ERROR='\033[0;31m'
 INFO='\033[0;36m'


### PR DESCRIPTION
Just some e2e testing tweaks I needed lately:
- Making the shebang environment agnostic (like NixOs does not have `/bin/bash`)
- Removing docker container on down else up will fail with container already exists error