### PR TITLE
fix: warnings from new clippy lints (relating to `#[must_use]`)

### DIFF
--- a/core/src/compile/address.rs
+++ b/core/src/compile/address.rs
@@ -31,6 +31,7 @@ impl Address {
         self.0.is_empty()
     }
 
+    #[must_use]
     pub fn root(&self) -> Self {
         self.iter().map(|node| node.to_string()).take(1).collect()
     }
@@ -50,6 +51,7 @@ impl Address {
         self.0.pop_back()
     }
 
+    #[must_use]
     #[inline]
     pub fn into_shallower(mut self) -> Self {
         self.shallower().unwrap();
@@ -72,6 +74,7 @@ impl Address {
         self.0.is_empty()
     }
 
+    #[must_use]
     #[inline]
     pub fn into_within(mut self, scope: &str) -> Self {
         self.within(scope);
@@ -84,6 +87,7 @@ impl Address {
         self
     }
 
+    #[must_use]
     #[inline]
     pub fn into_at(mut self, attribute: &str) -> Self {
         self.at(attribute);
@@ -114,6 +118,7 @@ impl Address {
         Some(out)
     }
 
+    #[must_use]
     pub fn concat(&self, other: &Self) -> Self {
         let mut out = self.clone();
         out.extend(other.clone().into_iter());
@@ -126,6 +131,7 @@ impl Address {
         (root, relative)
     }
 
+    #[must_use]
     pub fn common_root(&self, other: &Self) -> Self {
         self.iter()
             .zip(other.iter())

--- a/core/src/schema/content/mod.rs
+++ b/core/src/schema/content/mod.rs
@@ -278,6 +278,7 @@ impl Content {
         self.as_nullable().is_some()
     }
 
+    #[must_use]
     pub fn into_nullable(self) -> Self {
         if !self.is_nullable() {
             Content::OneOf(vec![self, Content::null()].into_iter().collect())
@@ -286,6 +287,7 @@ impl Content {
         }
     }
 
+    #[must_use]
     pub fn into_hidden(self) -> Self {
         if !self.is_hidden() {
             Content::Hidden(HiddenContent {
@@ -304,6 +306,7 @@ impl Content {
         matches!(self, Self::Unique(_))
     }
 
+    #[must_use]
     pub fn into_unique(self) -> Self {
         if !self.is_unique() {
             Content::Unique(UniqueContent {

--- a/core/src/schema/content/number.rs
+++ b/core/src/schema/content/number.rs
@@ -18,6 +18,7 @@ pub enum NumberContentKind {
 }
 
 impl NumberContentKind {
+    #[must_use]
     pub fn upcast(self) -> Self {
         match self {
             Self::U64 => Self::I64,

--- a/synth/src/cli/export.rs
+++ b/synth/src/cli/export.rs
@@ -92,7 +92,7 @@ pub(crate) fn create_and_insert_values<T: DataSource>(
 
     match &values {
         SamplerOutput::Collection(name, collection) => {
-            insert_data(datasource, &name.to_string(), collection)
+            insert_data(datasource, name.as_ref(), collection)
         }
         SamplerOutput::Namespace(ref namespace) => {
             for (name, collection) in namespace {

--- a/synth/src/cli/mongo.rs
+++ b/synth/src/cli/mongo.rs
@@ -163,7 +163,7 @@ impl ExportStrategy for MongoExportStrategy {
 
         match &output {
             SamplerOutput::Collection(name, values) => {
-                self.insert_data(&name.to_string(), values, &mut client)
+                self.insert_data(name.as_ref(), values, &mut client)
             }
             SamplerOutput::Namespace(ref namespace) => {
                 for (name, values) in namespace {


### PR DESCRIPTION
Fixes some clippy warnings:
* https://rust-lang.github.io/rust-clippy/master/index.html#return_self_not_must_use
* https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_to_owned