### PR TITLE
docs: init and date_time update

### DIFF
--- a/docs/blog/2021-03-08-mern.md
+++ b/docs/blog/2021-03-08-mern.md
@@ -298,6 +298,12 @@ The `time` field has been correctly detected as an array of values. First of all
 }
 ```
 
+:::caution
+
+`date_time` is now a generator on its own and is no longer a subtype of the `string` generator
+
+:::
+
 ### Name
 
 Finally, the movie name field should be populated with realistic looking movie names.

--- a/docs/blog/2021-08-31-seeding-databases-tutorial.md
+++ b/docs/blog/2021-08-31-seeding-databases-tutorial.md
@@ -592,7 +592,7 @@ together in one object. For that we need the [`object`][synth-object] type:
 
 Now we have everything we need to finish writing down
 our [`User` model](#prisma-is-awesome) as a `synth` schema. A quick lookup of
-the [documentation pages][synth-datetime] will tell us how to generate
+the [documentation pages][synth-string] will tell us how to generate
 the `createdAt` and `nickname` fields.
 
 Here is the finished result for our `User.json` collection:
@@ -629,6 +629,12 @@ Here is the finished result for our `User.json` collection:
     }
 }
 ```
+
+:::caution
+
+[`date_time`][synth-datetime] is now a generator on its own and is no longer a subtype of the `string` generator
+
+:::
 
 ### Making sure our constraints are satisfied
 
@@ -716,6 +722,12 @@ Here is the end result:
   }
 }
 ```
+
+:::caution
+
+[`date_time`][synth-datetime] is now a generator on its own and is no longer a subtype of the `string` generator
+
+:::
 
 It all looks pretty similar to the `User.json` collection, except for one
 important difference at the line
@@ -838,7 +850,7 @@ community would be happy to help if you encounter an issue!
 
 [synth-modifiers]: /docs/content/modifiers
 
-[synth-datetime]: /docs/content/string#date_time
+[synth-datetime]: /docs/content/date-time
 
 [synth-optional]: /docs/content/modifiers#optional
 

--- a/docs/docs/content/index.md
+++ b/docs/docs/content/index.md
@@ -21,7 +21,6 @@ various classes of string:
   * [pattern](string#pattern) takes a regular expression and
   generates matching strings
   * [uuid](string#uuid) generates hyphenated UUIDs
-  * [date_time](string#date_time) generates dates and times,
   optionally with time zone
   * [faker](string#faker) has a large number of generators for names,
   contact information, credit card numbers, sentences, and much more
@@ -33,6 +32,7 @@ various classes of string:
   within length limits
   * [categorical](string#categorical) is like a
   [one_of](one-of) specialized for strings
+* [date_time](date-time) generates dates and times
 * [object](object) creates an object with string keys containing
 generators for the values
 * [array](array) fills an array of the given length with elements of

--- a/docs/docs/examples/bank.md
+++ b/docs/docs/examples/bank.md
@@ -46,7 +46,7 @@ application testing.
 We first create a new workspace to import our dataset into Synth:
 
 ```bash
-mkdir synth_workspace && cd synth_workspace && synth init
+mkdir synth_workspace && cd synth_workspace
 ```
 
 Synth supports importing from JSON files. To create a namespace, copy the JSON blob below to a file outside your workspace and use the `import` command:
@@ -163,10 +163,9 @@ At this stage, we can run the `tree` command to see how the `synth import` sub-c
 ```bash
 $ tree -a
 .
-├── bank_db
-│   ├── transactions.json
-│   └── users.json
-└── .synth
+└── bank_db
+    ├── transactions.json
+    └── users.json
 ```
 
 The directory `bank_db` (remember from [Core Concepts](../getting_started/core-concepts) a subdirectory in a workspace represents a

--- a/docs/docs/examples/bank.md
+++ b/docs/docs/examples/bank.md
@@ -175,7 +175,7 @@ We can now generate data from our namespace using the `synth generate` sub-comma
 into [`jq`](https://stedolan.github.io/jq/download/) for the auto-formatting but this is optional.)
 
 ```bash
-synth generate bank_db/ | jq
+synth generate bank_db | jq
 {
   "transactions": [
     {

--- a/docs/docs/getting_started/hello-world.md
+++ b/docs/docs/getting_started/hello-world.md
@@ -55,7 +55,6 @@ and you should see an output very close to the output of the snippet.
 * For more complex real life examples, see the [examples][examples] section.
 
 [synth]: cli.md
-[synth-init]: cli.md#command-init
 [schema]: schema.md
 [generators]: ../content/object.md
 [core-concepts]: core-concepts.md

--- a/docs/docs/getting_started/hello-world.md
+++ b/docs/docs/getting_started/hello-world.md
@@ -44,7 +44,7 @@ data.
 Finally, run
 
 ```bash
-synth generate hello_synth/
+synth generate hello_synth
 ```
 
 and you should see an output very close to the output of the snippet.

--- a/docs/docs/other/telemetry.md
+++ b/docs/docs/other/telemetry.md
@@ -60,7 +60,6 @@ Synth's telemetry collects 8 fields:
   at `~/.config/synth/config.json`
 - `command`: The command that was issued by the user. This is a text field whose
   value is one of the following:
-  - `init`
   - `import`
   - `generate`
   - `telemetry::enabled`
@@ -93,7 +92,6 @@ activity:
       "categorical": {
           "import": 1,
           "generate": 10,
-          "init": 1,
           "telemetry::enabled": 10,
           "telemetry::disabled": 1
       }

--- a/www/components/Examples.tsx
+++ b/www/components/Examples.tsx
@@ -6,12 +6,10 @@ import Section from "./Section";
 const timeSeriesExample = {
     "type": "object",
     "timestamp": {
-        "type": "string",
-        "date_time": {
-            "format": "%Y-%m-%dT%H:%M:%S",
-            "subtype": "naive_date_time",
-            "begin": "2020-06-07T12:00:00"
-        }
+        "type": "date_time",
+        "subtype": "naive_date_time",
+        "format": "%Y-%m-%dT%H:%M:%S",
+        "begin": "2020-06-07T12:00:00"
     },
     "px_last": {
         "type": "number",
@@ -62,11 +60,10 @@ const eventsExample = {
         }
     },
     "timestamp": {
-        "type": "string",
-        "date_time": {
-            "format": "%Y-%m-%dT%H:%M:%S",
-            "subtype": "naive_date_time",
-            "begin": "2020-06-07T12:00:00"
+        "type": "date_time",
+        "subtype": "naive_date_time",
+        "format": "%Y-%m-%dT%H:%M:%S",
+        "begin": "2020-06-07T12:00:00"
         }
     },
     "ip_v4": {


### PR DESCRIPTION
While working on #255 I found some references to the deprecated `init` command which this PR removes.

`date_time` examples are also updated in docs or cautions pills added for blog posts to keep their historical value. This closes #267 but not #257 (which has its own PR - #258).

Trailing forward-slashes are also removed from `generate` namespaces to make them cleaner