### PR TITLE
refactor: remove unwrap() from Config::save()

### DIFF
--- a/synth/src/cli/config.rs
+++ b/synth/src/cli/config.rs
@@ -81,6 +81,7 @@ impl Config {
         let mut config_file_path = std::fs::OpenOptions::new()
             .write(true)
             .create(true)
+            .truncate(true)
             .open(Self::file_path()?)?;
 
         serde_json::to_writer_pretty(&mut config_file_path, &self)?;

--- a/synth/src/cli/config.rs
+++ b/synth/src/cli/config.rs
@@ -26,10 +26,10 @@ macro_rules! config {
 
         $(
             #[allow(dead_code)]
-            pub fn $setter($val_name: $ty) {
+            pub fn $setter($val_name: $ty) -> Result<()> {
                 let mut config = CONFIG.lock().unwrap();
                 config.$val_name = Some($val_name);
-                config.save();
+                config.save()
             }
             #[allow(dead_code)]
             pub fn $getter() -> Option<$ty> {
@@ -70,19 +70,21 @@ impl Config {
         Ok(synth_config_dir.join("synth"))
     }
 
-    fn save(&self) {
-        // There are way too many unwraps here.
+    fn save(&self) -> Result<()> {
         // Create config dir if it doesn't exist
-        let config_dir = Self::synth_config_dir().unwrap();
+        let config_dir = Self::synth_config_dir()?;
         if !config_dir.exists() {
-            std::fs::create_dir_all(&config_dir).unwrap();
+            std::fs::create_dir_all(&config_dir)?;
         }
+
         // Save the config
         let mut config_file_path = std::fs::OpenOptions::new()
             .write(true)
             .create(true)
-            .open(Self::file_path().unwrap())
-            .unwrap();
-        serde_json::to_writer_pretty(&mut config_file_path, &self).unwrap();
+            .open(Self::file_path()?)?;
+
+        serde_json::to_writer_pretty(&mut config_file_path, &self)?;
+
+        Ok(())
     }
 }

--- a/synth/src/version.rs
+++ b/synth/src/version.rs
@@ -34,7 +34,7 @@ pub fn notify_new_version_message() -> Result<Option<String>> {
 
     let (version_info, latest_version) = version_update_info()?;
     let mut ret = None;
-    config::set_version_check_delay(now + chrono::Duration::days(1));
+    config::set_version_check_delay(now + chrono::Duration::days(1))?;
 
     // if this is `Some`, our version is out of date.
     if let Some(version_info) = version_info {
@@ -73,10 +73,13 @@ fn has_notified_for_version(version: Version) -> bool {
     // If the set did not have this value present, true is returned.
     let has_notified = !seen_versions.insert(version_as_string);
 
-    // save seen versions
-    config::set_seen_versions(seen_versions);
+    // No further updating needed
+    if has_notified {
+        return true;
+    }
 
-    has_notified
+    // Save seen versions
+    config::set_seen_versions(seen_versions).is_err()
 }
 
 fn latest_version() -> Result<Version> {


### PR DESCRIPTION
Removes a bunch of `unwrap()` from `Config::save()` to improve our telemetry logs. The change bubbled up to some functions...