### PR TITLE
refactor: postgres u32

### DIFF
--- a/core/src/graph/mod.rs
+++ b/core/src/graph/mod.rs
@@ -382,7 +382,7 @@ impl Encode<'_, Postgres> for Value {
                 }
                 Number::U8(i) => <i8 as Encode<'_, Postgres>>::encode_by_ref(&(i as i8), buf),
                 Number::U16(i) => <i16 as Encode<'_, Postgres>>::encode_by_ref(&(i as i16), buf),
-                Number::U32(i) => <u32 as Encode<'_, Postgres>>::encode_by_ref(&i, buf),
+                Number::U32(i) => <i32 as Encode<'_, Postgres>>::encode_by_ref(&(i as i32), buf),
                 Number::U64(i) => <i64 as Encode<'_, Postgres>>::encode_by_ref(&(i as i64), buf),
                 Number::U128(i) => {
                     <sqlx::types::Decimal as Encode<'_, Postgres>>::encode_by_ref(&i.into(), buf)


### PR DESCRIPTION
While working on #282, I found that `sqlx` will eventually drop the `u32` type for postgres in their 1602 PR. This is likely to happen in a future release of `sqlx`, however this PR gets us ready for once it happens.