### PR TITLE
test: fix verbose use of array constant length

### DIFF
--- a/synth/testing_harness/mysql/warnings/i32/i32.json
+++ b/synth/testing_harness/mysql/warnings/i32/i32.json
@@ -19,8 +19,5 @@
         "integer": "@i32.content.def",
         "bigint": "@i32.content.def"
     },
-    "length": {
-        "type": "number",
-        "constant": 1
-    }
+    "length": 1
 }

--- a/synth/testing_harness/mysql/warnings/i64/i64.json
+++ b/synth/testing_harness/mysql/warnings/i64/i64.json
@@ -19,8 +19,5 @@
         "integer": "@i64.content.def",
         "bigint": "@i64.content.def"
     },
-    "length": {
-        "type": "number",
-        "constant": 1
-    }
+    "length": 1
 }

--- a/synth/testing_harness/mysql/warnings/u32/u32.json
+++ b/synth/testing_harness/mysql/warnings/u32/u32.json
@@ -19,8 +19,5 @@
         "integer": "@u32.content.def",
         "bigint": "@u32.content.def"
     },
-    "length": {
-        "type": "number",
-        "constant": 1
-    }
+    "length": 1
 }

--- a/synth/testing_harness/mysql/warnings/u64/u64.json
+++ b/synth/testing_harness/mysql/warnings/u64/u64.json
@@ -19,8 +19,5 @@
         "integer": "@u64.content.def",
         "bigint": "@u64.content.def"
     },
-    "length": {
-        "type": "number",
-        "constant": 1
-    }
+    "length": 1
 }

--- a/synth/testing_harness/postgres/arrays/arrays.json
+++ b/synth/testing_harness/postgres/arrays/arrays.json
@@ -313,10 +313,7 @@
             },
             "content": {
                 "type": "array",
-                "length": {
-                    "type": "number",
-                    "constant": 8
-                },
+                "length": 8,
                 "content": {
                     "type": "number",
                     "subtype": "i32",

--- a/synth/testing_harness/postgres/warnings/i32/i32.json
+++ b/synth/testing_harness/postgres/warnings/i32/i32.json
@@ -22,8 +22,5 @@
         "integer": "@i32.content.def",
         "bigint": "@i32.content.def"
     },
-    "length": {
-        "type": "number",
-        "constant": 1
-    }
+    "length": 1
 }

--- a/synth/testing_harness/postgres/warnings/i64/i64.json
+++ b/synth/testing_harness/postgres/warnings/i64/i64.json
@@ -22,8 +22,5 @@
         "integer": "@i64.content.def",
         "bigint": "@i64.content.def"
     },
-    "length": {
-        "type": "number",
-        "constant": 1
-    }
+    "length": 1
 }

--- a/synth/testing_harness/postgres/warnings/u32/u32.json
+++ b/synth/testing_harness/postgres/warnings/u32/u32.json
@@ -22,8 +22,5 @@
         "integer": "@u32.content.def",
         "bigint": "@u32.content.def"
     },
-    "length": {
-        "type": "number",
-        "constant": 1
-    }
+    "length": 1
 }

--- a/synth/testing_harness/postgres/warnings/u64/u64.json
+++ b/synth/testing_harness/postgres/warnings/u64/u64.json
@@ -22,8 +22,5 @@
         "integer": "@u64.content.def",
         "bigint": "@u64.content.def"
     },
-    "length": {
-        "type": "number",
-        "constant": 1
-    }
+    "length": 1
 }


### PR DESCRIPTION
With the new improved errors, these tests are failing since they could just be `length: 1`