### PR TITLE
refactor: more descriptive float warnings

### DIFF
--- a/synth/src/datasource/relational_datasource.rs
+++ b/synth/src/datasource/relational_datasource.rs
@@ -185,6 +185,12 @@ where
                         column_info.data_type, collection_name, column_info.column_name
                     )
                 }
+                (Value::Number(Number::F32(_)), "float8" | "double") => {
+                    warn!(
+                        "Trying to put a f32 into a {} typed column {}.{}",
+                        column_info.data_type, collection_name, column_info.column_name
+                    )
+                }
                 //TODO: More variants
                 _ => {}
             }

--- a/synth/src/datasource/relational_datasource.rs
+++ b/synth/src/datasource/relational_datasource.rs
@@ -185,6 +185,12 @@ where
                         column_info.data_type, collection_name, column_info.column_name
                     )
                 }
+                (Value::Number(Number::F64(_)), "float4" | "float") => {
+                    warn!(
+                        "Trying to put a f64 into a {} typed column {}.{}",
+                        column_info.data_type, collection_name, column_info.column_name
+                    )
+                }
                 (Value::Number(Number::F32(_)), "float8" | "double") => {
                     warn!(
                         "Trying to put a f32 into a {} typed column {}.{}",

--- a/synth/testing_harness/mysql/warnings/f32/f32.json
+++ b/synth/testing_harness/mysql/warnings/f32/f32.json
@@ -1,0 +1,21 @@
+{
+    "type": "array",
+    "content": {
+        "type": "object",
+        "def": {
+            "type": "hidden",
+            "content": {
+                "type": "number",
+                "subtype": "f32",
+                "range": {
+                    "low": 0.25,
+                    "high": 32767.325,
+                    "step": 0.05
+                }
+            }
+        },
+        "float": "@f32.content.def",
+        "double": "@f32.content.def"
+    },
+    "length": 1
+}

--- a/synth/testing_harness/mysql/warnings/f32/schema.sql
+++ b/synth/testing_harness/mysql/warnings/f32/schema.sql
@@ -1,0 +1,8 @@
+drop table if exists f32;
+
+create table f32
+(
+    -- Unofficial types
+    `float` float NOT NULL,
+    `double` double NOT NULL
+);

--- a/synth/testing_harness/mysql/warnings/f32/warnings.txt
+++ b/synth/testing_harness/mysql/warnings/f32/warnings.txt
@@ -1,0 +1,1 @@
+Trying to put a f32 into a double typed column f32.double

--- a/synth/testing_harness/mysql/warnings/f64/f64.json
+++ b/synth/testing_harness/mysql/warnings/f64/f64.json
@@ -1,0 +1,21 @@
+{
+    "type": "array",
+    "content": {
+        "type": "object",
+        "def": {
+            "type": "hidden",
+            "content": {
+                "type": "number",
+                "subtype": "f64",
+                "range": {
+                    "low": 0.5,
+                    "high": 32767,
+                    "step": 0.05
+                }
+            }
+        },
+        "float": "@f64.content.def",
+        "double": "@f64.content.def"
+    },
+    "length": 1
+}

--- a/synth/testing_harness/mysql/warnings/f64/schema.sql
+++ b/synth/testing_harness/mysql/warnings/f64/schema.sql
@@ -1,0 +1,8 @@
+drop table if exists f64;
+
+create table f64
+(
+    -- Unofficial types
+    `float` float NOT NULL,
+    `double` double NOT NULL
+);

--- a/synth/testing_harness/mysql/warnings/f64/warnings.txt
+++ b/synth/testing_harness/mysql/warnings/f64/warnings.txt
@@ -1,0 +1,1 @@
+Trying to put a f64 into a float typed column f32.float

--- a/synth/testing_harness/postgres/warnings/f32/f32.json
+++ b/synth/testing_harness/postgres/warnings/f32/f32.json
@@ -1,0 +1,23 @@
+{
+    "type": "array",
+    "content": {
+        "type": "object",
+        "def": {
+            "type": "hidden",
+            "content": {
+                "type": "number",
+                "subtype": "f32",
+                "range": {
+                    "low": 0.25,
+                    "high": 32767.325,
+                    "step": 0.05
+                }
+            }
+        },
+        "float4": "@f32.content.def",
+        "float8": "@f32.content.def",
+        "real": "@f32.content.def",
+        "double_precision": "@f32.content.def"
+    },
+    "length": 1
+}

--- a/synth/testing_harness/postgres/warnings/f32/schema.sql
+++ b/synth/testing_harness/postgres/warnings/f32/schema.sql
@@ -1,0 +1,11 @@
+drop table if exists f32;
+
+create table f32
+(
+    float4 float4 NOT NULL,
+    float8 float8 NOT NULL,
+
+    -- Unofficial types
+    real real NOT NULL,
+    double_precision double precision NOT NULL
+);

--- a/synth/testing_harness/postgres/warnings/f32/warnings.txt
+++ b/synth/testing_harness/postgres/warnings/f32/warnings.txt
@@ -1,0 +1,2 @@
+Trying to put a f32 into a float8 typed column f32.float8
+Trying to put a f32 into a float8 typed column f32.double_precision

--- a/synth/testing_harness/postgres/warnings/f64/f64.json
+++ b/synth/testing_harness/postgres/warnings/f64/f64.json
@@ -1,0 +1,23 @@
+{
+    "type": "array",
+    "content": {
+        "type": "object",
+        "def": {
+            "type": "hidden",
+            "content": {
+                "type": "number",
+                "subtype": "f64",
+                "range": {
+                    "low": 0.25,
+                    "high": 32767.325,
+                    "step": 0.05
+                }
+            }
+        },
+        "float4": "@f64.content.def",
+        "float8": "@f64.content.def",
+        "real": "@f64.content.def",
+        "double_precision": "@f64.content.def"
+    },
+    "length": 1
+}

--- a/synth/testing_harness/postgres/warnings/f64/schema.sql
+++ b/synth/testing_harness/postgres/warnings/f64/schema.sql
@@ -1,0 +1,11 @@
+drop table if exists f64;
+
+create table f64
+(
+    float4 float4 NOT NULL,
+    float8 float8 NOT NULL,
+
+    -- Unofficial types
+    real real NOT NULL,
+    double_precision double precision NOT NULL
+);

--- a/synth/testing_harness/postgres/warnings/f64/warnings.txt
+++ b/synth/testing_harness/postgres/warnings/f64/warnings.txt
@@ -1,0 +1,2 @@
+Trying to put a f64 into a float4 typed column f64.float4
+Trying to put a f64 into a float4 typed column f64.real


### PR DESCRIPTION
This is for our internal clickup issue (1e11y2v) to improve the message shown when trying to generate a f32 to a postgres double precision type.