### PR TITLE
ci: fix doc tests for single line items

### DIFF
--- a/synth/tests/docs.rs
+++ b/synth/tests/docs.rs
@@ -198,6 +198,15 @@ fn write_code_block(ns: &Path, block: Vec<Line>, tmp: &Path) -> Result<Option<St
             "length": 1,
             "content": "#
         )?;
+
+        // Make single line items a field in an object
+        if block.len() == 3 {
+            write!(
+                file,
+                r#"{{
+            "type": "object","#
+            )?;
+        }
     }
 
     for line in &block[1..block.len() - 1] {
@@ -220,6 +229,9 @@ fn write_code_block(ns: &Path, block: Vec<Line>, tmp: &Path) -> Result<Option<St
     }
 
     if is_synth && !is_array_block {
+        if block.len() == 3 {
+            writeln!(file, "}}")?;
+        }
         writeln!(file, "}}")?;
     }
 


### PR DESCRIPTION
Makes sure the CI doc tests handle single line items to close #309 